### PR TITLE
Add interactive terminal UI for config file creation and editing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Interactive config editor: `mqttaudio --configure`.** A full-screen terminal UI (ratatui) that creates
+  or edits the JSON config file with per-field help, the daemon's own validation before saving, and live
+  device testing: the output device picker plays per-channel test tones through the real playback pathway
+  (channel volumes, master gain, limiter, and bass management all apply, with live peak meters and a
+  channel sweep for speaker identification), and input devices get a live capture level meter. Every config
+  field is editable — a coverage test fails the build if a future config field lacks an editor binding.
+  Saves are sparse (only explicitly-set keys are written, so built-in defaults can evolve), atomic, preceded
+  by a `.bak` backup, and preserve unknown keys/comments in existing files.
+
 ### Changed
 
 - **`/ws` now actually streams the daemon's log lines (Sprint 14, D62).** The WebSocket log layer existed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "alsa"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -111,6 +117,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -124,7 +145,16 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.107",
+]
+
+[[package]]
+name = "atomic"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
+dependencies = [
+ "bytemuck",
 ]
 
 [[package]]
@@ -226,7 +256,16 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn",
+ "syn 2.0.107",
+]
+
+[[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec 0.6.3",
 ]
 
 [[package]]
@@ -235,8 +274,14 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.8.0",
 ]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bit-vec"
@@ -281,6 +326,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
+name = "by_address"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
+
+[[package]]
 name = "bytemuck"
 version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -303,6 +354,15 @@ name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "cc"
@@ -334,6 +394,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -417,7 +483,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -440,6 +506,29 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "compact_str"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -548,6 +637,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -573,6 +668,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags 2.12.1",
+ "crossterm_winapi",
+ "derive_more",
+ "document-features",
+ "mio",
+ "parking_lot",
+ "rustix",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -586,6 +708,50 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "csscolorparser"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
+dependencies = [
+ "lab",
+ "phf",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.107",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -714,6 +880,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
 
 [[package]]
+name = "deltae"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.107",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -762,7 +965,16 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.107",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -797,10 +1009,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "euclid"
+version = "0.22.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "extended"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af9673d8203fcb076b19dfd17e38b3d4ae9f44959416ea532ce72415a6020365"
+
+[[package]]
+name = "fancy-regex"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
+dependencies = [
+ "bit-set 0.5.3",
+ "regex",
+]
+
+[[package]]
+name = "fast-srgb8"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
 
 [[package]]
 name = "fastrand"
@@ -809,10 +1046,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "filedescriptor"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+dependencies = [
+ "libc",
+ "thiserror 1.0.69",
+ "winapi",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52051878f80a721bb68ebfbc930e07b65ba72f2da88968ea5c06fd6ca3d3a127"
+
+[[package]]
+name = "finl_unicode"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9844ddc3a6e533d62bba727eb6c28b5d360921d5175e9ff0f1e621a5c590a4d5"
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flume"
@@ -830,6 +1090,18 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
@@ -911,7 +1183,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -973,8 +1245,21 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -1015,9 +1300,34 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "heck"
@@ -1030,6 +1340,12 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
@@ -1289,6 +1605,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1316,7 +1644,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6717a8d2a5a929a1a2eb43a12812498ed141a0bcfb7e8f7844fbdbe4303bba9f"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.0",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
+dependencies = [
+ "darling",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -1361,6 +1713,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1377,7 +1738,7 @@ dependencies = [
  "combine",
  "jni-sys",
  "log",
- "thiserror",
+ "thiserror 1.0.69",
  "walkdir",
  "windows-sys 0.45.0",
 ]
@@ -1399,10 +1760,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "kasuari"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899"
+dependencies = [
+ "hashbrown 0.16.0",
+ "portable-atomic",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "lab"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf36173d4167ed999940f804952e6b08197cae5ad5d572eb4db150ce8ad5d58f"
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -1421,6 +1805,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "libredox"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1428,6 +1818,15 @@ checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
 dependencies = [
  "bitflags 2.12.1",
  "libc",
+]
+
+[[package]]
+name = "line-clipping"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
+dependencies = [
+ "bitflags 2.12.1",
 ]
 
 [[package]]
@@ -1443,6 +1842,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1456,6 +1861,25 @@ name = "log"
 version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+
+[[package]]
+name = "lru"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
+dependencies = [
+ "hashbrown 0.17.1",
+]
+
+[[package]]
+name = "mac_address"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
+dependencies = [
+ "nix",
+ "winapi",
+]
 
 [[package]]
 name = "mach2"
@@ -1477,6 +1901,21 @@ name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
+name = "memmem"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a64a92489e2744ce060c349162be1c5f33c6969234104dbd99ddb5feb08b8c15"
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "mime"
@@ -1507,6 +1946,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -1529,6 +1969,7 @@ dependencies = [
  "parking_lot",
  "proptest",
  "rand 0.8.5",
+ "ratatui",
  "reqwest",
  "ringbuf",
  "rubato",
@@ -1576,7 +2017,7 @@ dependencies = [
  "log",
  "ndk-sys",
  "num_enum",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1592,6 +2033,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
 dependencies = [
  "jni-sys",
+]
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.12.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
 ]
 
 [[package]]
@@ -1632,6 +2086,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
 name = "num-derive"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1639,7 +2099,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -1679,7 +2139,16 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.107",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1812,7 +2281,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -1838,6 +2307,39 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordered-float"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "palette"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cbf71184cc5ecc2e4e1baccdb21026c20e5fc3dcf63028a086131b3ab00b6e6"
+dependencies = [
+ "approx",
+ "fast-srgb8",
+ "libm",
+ "palette_derive",
+]
+
+[[package]]
+name = "palette_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5030daf005bface118c096f510ffb781fc28f9ab6a32ab224d8631be6851d30"
+dependencies = [
+ "by_address",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.107",
+]
 
 [[package]]
 name = "parking_lot"
@@ -1867,6 +2369,101 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pest"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.107",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
+dependencies = [
+ "pest",
+ "sha2",
+]
+
+[[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.107",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -1915,6 +2512,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
 name = "potential_utf"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1922,6 +2525,12 @@ checksum = "84df19adbe5b5a0782edcab45899906947ab039ccf4573713735ee7de1e6b08a"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1939,7 +2548,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -1975,8 +2584,8 @@ version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
- "bit-set",
- "bit-vec",
+ "bit-set 0.8.0",
+ "bit-vec 0.8.0",
  "bitflags 2.12.1",
  "num-traits",
  "rand 0.9.4",
@@ -2008,6 +2617,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
@@ -2078,6 +2693,96 @@ dependencies = [
 ]
 
 [[package]]
+name = "ratatui"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1695748e3a735b34968c887ceea5a380b43545903868ae8f5b666593100f6b68"
+dependencies = [
+ "instability",
+ "ratatui-core",
+ "ratatui-crossterm",
+ "ratatui-macros",
+ "ratatui-termwiz",
+ "ratatui-widgets",
+ "serde",
+]
+
+[[package]]
+name = "ratatui-core"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42d3603f354bba8c595fa47860e60142d7372b7210c27044c6a7d0e1a4336b44"
+dependencies = [
+ "bitflags 2.12.1",
+ "compact_str",
+ "critical-section",
+ "hashbrown 0.17.1",
+ "indoc",
+ "itertools 0.14.0",
+ "kasuari",
+ "lru",
+ "palette",
+ "serde",
+ "strum",
+ "thiserror 2.0.18",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width",
+]
+
+[[package]]
+name = "ratatui-crossterm"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2867bedcbd6a690ca4f8672a687b730ec07660c79844517b084311b529980c"
+dependencies = [
+ "cfg-if",
+ "crossterm",
+ "instability",
+ "ratatui-core",
+]
+
+[[package]]
+name = "ratatui-macros"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80fac59720679490d89d200df411faa249be728681adcabed3d047ae72c48f1d"
+dependencies = [
+ "ratatui-core",
+ "ratatui-widgets",
+]
+
+[[package]]
+name = "ratatui-termwiz"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "386b8ff8f74ed749509391c56d549761a2fcdb408e1f42e467286bcb7dac8967"
+dependencies = [
+ "ratatui-core",
+ "termwiz",
+]
+
+[[package]]
+name = "ratatui-widgets"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef4f17dd7ac3abf5adc2b920a03c61eee4bfe6a88fa5191936895525371d79c"
+dependencies = [
+ "bitflags 2.12.1",
+ "hashbrown 0.17.1",
+ "indoc",
+ "instability",
+ "itertools 0.14.0",
+ "line-clipping",
+ "ratatui-core",
+ "serde",
+ "strum",
+ "time",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
 name = "rayon"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2123,7 +2828,7 @@ checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
  "getrandom 0.2.16",
  "libredox",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2245,7 +2950,7 @@ dependencies = [
  "rustls-native-certs",
  "rustls-pemfile 2.2.0",
  "rustls-webpki",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-rustls",
 ]
@@ -2255,6 +2960,15 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustfft"
@@ -2420,6 +3134,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2446,7 +3166,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -2523,6 +3243,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2541,6 +3282,12 @@ dependencies = [
  "cc",
  "dasp",
 ]
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
@@ -2590,6 +3337,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strength_reduce"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2600,6 +3353,27 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.107",
+]
 
 [[package]]
 name = "subtle"
@@ -2804,6 +3578,17 @@ dependencies = [
 
 [[package]]
 name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "2.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a26dbd934e5451d21ef060c018dae56fc073894c5a7896f882928a76e6d081b"
@@ -2833,7 +3618,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -2884,12 +3669,84 @@ dependencies = [
 ]
 
 [[package]]
+name = "terminfo"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
+dependencies = [
+ "fnv",
+ "nom",
+ "phf",
+ "phf_codegen",
+]
+
+[[package]]
+name = "termios"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "411c5bf740737c7918b8b1fe232dca4dc9f8e754b8ad5e20966814001ed0ac6b"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "termwiz"
+version = "0.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
+dependencies = [
+ "anyhow",
+ "base64 0.22.1",
+ "bitflags 2.12.1",
+ "fancy-regex",
+ "filedescriptor",
+ "finl_unicode",
+ "fixedbitset",
+ "hex",
+ "lazy_static",
+ "libc",
+ "log",
+ "memmem",
+ "nix",
+ "num-derive",
+ "num-traits",
+ "ordered-float",
+ "pest",
+ "pest_derive",
+ "phf",
+ "sha2",
+ "signal-hook",
+ "siphasher",
+ "terminfo",
+ "termios",
+ "thiserror 1.0.69",
+ "ucd-trie",
+ "unicode-segmentation",
+ "vtparse",
+ "wezterm-bidi",
+ "wezterm-blob-leases",
+ "wezterm-color-types",
+ "wezterm-dynamic",
+ "wezterm-input-types",
+ "winapi",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -2900,7 +3757,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.107",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -2911,6 +3779,27 @@ checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "libc",
+ "num-conv",
+ "num_threads",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "tinystr"
@@ -2957,7 +3846,7 @@ checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -3109,7 +3998,7 @@ checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -3190,7 +4079,7 @@ dependencies = [
  "log",
  "rand 0.8.5",
  "sha1",
- "thiserror",
+ "thiserror 1.0.69",
  "utf-8",
 ]
 
@@ -3199,6 +4088,12 @@ name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unarray"
@@ -3217,6 +4112,35 @@ name = "unicode-ident"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
+name = "unicode-truncate"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
+dependencies = [
+ "itertools 0.14.0",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "untrusted"
@@ -3255,6 +4179,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "uuid"
+version = "1.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
+dependencies = [
+ "atomic",
+ "getrandom 0.4.2",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3271,6 +4207,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vtparse"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9b2acfb050df409c972a37d3b8e08cdea3bddb0c09db9d53137e504cfabed0"
+dependencies = [
+ "utf8parse",
+]
 
 [[package]]
 name = "wait-timeout"
@@ -3312,7 +4257,16 @@ version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.46.0",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -3338,7 +4292,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.107",
  "wasm-bindgen-shared",
 ]
 
@@ -3373,7 +4327,7 @@ checksum = "9f07d2f20d4da7b26400c9f4a0511e6e0345b040694e8a75bd41d578fa4421d7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.107",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3385,6 +4339,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bad67dc8b2a1a6e5448428adec4c3e84c43e561d8c9ee8a9e5aabeb193ec41d1"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
 ]
 
 [[package]]
@@ -3401,6 +4377,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.12.1",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3408,6 +4396,78 @@ checksum = "9367c417a924a74cae129e6a2ae3b47fabb1f8995595ab474029da749a8be120"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "wezterm-bidi"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0a6e355560527dd2d1cf7890652f4f09bb3433b6aadade4c9b5ed76de5f3ec"
+dependencies = [
+ "log",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wezterm-blob-leases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692daff6d93d94e29e4114544ef6d5c942a7ed998b37abdc19b17136ea428eb7"
+dependencies = [
+ "getrandom 0.3.4",
+ "mac_address",
+ "sha2",
+ "thiserror 1.0.69",
+ "uuid",
+]
+
+[[package]]
+name = "wezterm-color-types"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7de81ef35c9010270d63772bebef2f2d6d1f2d20a983d27505ac850b8c4b4296"
+dependencies = [
+ "csscolorparser",
+ "deltae",
+ "lazy_static",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wezterm-dynamic"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f2ab60e120fd6eaa68d9567f3226e876684639d22a4219b313ff69ec0ccd5ac"
+dependencies = [
+ "log",
+ "ordered-float",
+ "strsim",
+ "thiserror 1.0.69",
+ "wezterm-dynamic-derive",
+]
+
+[[package]]
+name = "wezterm-dynamic-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c0cf2d539c645b448eaffec9ec494b8b19bd5077d9e58cb1ae7efece8d575b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "wezterm-input-types"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7012add459f951456ec9d6c7e6fc340b1ce15d6fc9629f8c42853412c029e57e"
+dependencies = [
+ "bitflags 1.3.2",
+ "euclid",
+ "lazy_static",
+ "serde",
+ "wezterm-dynamic",
 ]
 
 [[package]]
@@ -3514,7 +4574,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -3525,7 +4585,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -3903,6 +4963,94 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn 2.0.107",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.107",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.12.1",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
+
+[[package]]
 name = "writeable"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3928,7 +5076,7 @@ checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.107",
  "synstructure",
 ]
 
@@ -3949,7 +5097,7 @@ checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -3969,7 +5117,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.107",
  "synstructure",
 ]
 
@@ -4009,5 +5157,5 @@ checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.107",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,9 @@ serde_json = "1.0"
 # CLI parsing
 clap = { version = "4.5", features = ["derive"] }
 
+# Terminal UI for the interactive config editor
+ratatui = "0.30"
+
 # Async runtime
 tokio = { version = "1", features = ["full"] }
 

--- a/README.md
+++ b/README.md
@@ -147,7 +147,20 @@ mosquitto_pub -t audio/commands -m '{
 
 ## Configuration
 
-For production use, create a config file:
+The easiest way to create or edit a config file is the built-in interactive editor:
+
+```bash
+./mqttaudio --configure
+```
+
+It walks every config section with inline help and validation, includes a device picker that can play a
+test tone per speaker **through the real playback pathway** (so you hear exactly what the daemon will do,
+including channel volumes, the limiter, and bass management), and a live level meter for microphone inputs.
+Only the settings you explicitly change are written to the file — everything else stays on the daemon's
+built-in defaults — and any existing file is backed up to `<name>.bak` before saving. Hand-written comments
+and unknown keys in an existing file are preserved.
+
+Alternatively, create a config file by hand:
 
 ```json
 {

--- a/config.example.json
+++ b/config.example.json
@@ -22,15 +22,15 @@
     "device": null,
     "sample_rate": 48000,
     "buffer_size": 512,
-    "channel_names": {
-      "0": "front_left",
-      "1": "front_right",
-      "2": "center",
-      "3": "lfe",
-      "4": "rear_left",
-      "5": "rear_right",
-      "6": "side_left",
-      "7": "side_right"
+    "channel_aliases": {
+      "front_left": 0,
+      "front_right": 1,
+      "center": 2,
+      "lfe": 3,
+      "rear_left": 4,
+      "rear_right": 5,
+      "side_left": 6,
+      "side_right": 7
     },
     "channel_volumes": {
       "lfe": 0.7,
@@ -43,7 +43,7 @@
       "sample_rate: Output sample rate in Hz. Common values: 44100, 48000, 96000",
       "buffer_size: Audio buffer size in frames. Smaller = lower latency but higher CPU",
       "  Common values: 256 (low latency), 512 (balanced), 1024 (high compatibility)",
-      "channel_names: Optional mapping of channel numbers to human-readable names",
+      "channel_aliases: Optional mapping of friendly channel names to channel indices",
       "channel_volumes: Per-channel calibration (0.0-1.0) to compensate for hardware differences"
     ]
   },
@@ -114,15 +114,15 @@
         "device": "USB Audio Interface",
         "sample_rate": 48000,
         "buffer_size": 512,
-        "channel_names": {
-          "0": "zone1_left",
-          "1": "zone1_right",
-          "2": "zone2_left",
-          "3": "zone2_right",
-          "4": "zone3_left",
-          "5": "zone3_right",
-          "6": "zone4_left",
-          "7": "zone4_right"
+        "channel_aliases": {
+          "zone1_left": 0,
+          "zone1_right": 1,
+          "zone2_left": 2,
+          "zone2_right": 3,
+          "zone3_left": 4,
+          "zone3_right": 5,
+          "zone4_left": 6,
+          "zone4_right": 7
         }
       },
       "cache": {

--- a/docs/bugs.md
+++ b/docs/bugs.md
@@ -311,6 +311,13 @@ progress, so they aren't lost. Each entry names the owning sprint where known.
   emitting discrete events from the control-thread mutation points is an optimization. The web meters render the
   output bars live; per-input meters show nothing until (1) lands.
 
+## Noticed while building the config editor (Sprint: config editor)
+
+- **`config.example.json` still documents the removed `audio.channel_names` field** (top-level example,
+  `_notes`, and the nested production example). The field was removed in Sprint 14 (D60); the live alias
+  mechanism is `audio.channel_aliases`. The example parses fine (unknown keys are tolerated) but teaches a
+  dead field. Out of scope for the config-editor change; the example should be updated to `channel_aliases`.
+
 ## Implementation notes
 
 - **Auto voice-id format: `_auto_<millis>_<n>` shipped, reconciling DECISIONS.md D24 vs D41/Sprint-9 F5.**

--- a/docs/bugs.md
+++ b/docs/bugs.md
@@ -313,10 +313,11 @@ progress, so they aren't lost. Each entry names the owning sprint where known.
 
 ## Noticed while building the config editor (Sprint: config editor)
 
-- **`config.example.json` still documents the removed `audio.channel_names` field** (top-level example,
-  `_notes`, and the nested production example). The field was removed in Sprint 14 (D60); the live alias
-  mechanism is `audio.channel_aliases`. The example parses fine (unknown keys are tolerated) but teaches a
-  dead field. Out of scope for the config-editor change; the example should be updated to `channel_aliases`.
+- **`config.example.json` still documents the removed `audio.channel_names` field (RESOLVED).** The field
+  was removed in Sprint 14 (D60); the live alias mechanism is `audio.channel_aliases`. The example parsed
+  fine (unknown keys are tolerated) but taught a dead field. Both occurrences (top-level example and the
+  nested production example) plus the `_notes` line now use `channel_aliases` with the correct
+  name-to-index direction.
 
 ## Implementation notes
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -23,6 +23,7 @@ OPTIONS:
   --http-port <PORT>           Enable the HTTP REST/WebSocket server on this port
   --max-cache-mb <MB>          Override the memory cache cap in MiB (0 = auto-detect a bounded cap)
   -v, --verbose                Enable verbose logging (debug level)
+  --configure                  Launch the interactive configuration editor and exit
   --list-devices               List available audio output devices and exit
   --list-inputs                List available audio input devices and exit
   --help                       Print help information
@@ -33,6 +34,25 @@ The value-taking flags are optional overrides: when omitted they fall back to th
 "config default" shown is the built-in value applied when neither the flag nor the config sets it. These are
 config-level defaults, not clap defaults, so `--help` does not display them. `--max-cache-mb 0` (and leaving
 `cache.max_memory_mb` at `0`) selects an auto-detected **bounded** cap — not an unlimited cache.
+
+## Interactive Editor
+
+`mqttaudio --configure` opens a full-screen terminal editor covering every setting documented on this page,
+with per-field help, the same validation the daemon applies at startup, and live device testing:
+
+- The **output device picker** lists real devices and can play a test tone on any single output channel
+  through the actual playback pathway — channel volumes, master gain, the limiter, and bass management from
+  the in-progress config all apply, with live per-channel peak meters. A 50 Hz bass tone option makes an
+  enabled bass-management crossover audible, and a sweep mode steps through all channels for speaker
+  identification.
+- The **input device picker** shows a live per-channel level meter through the daemon's real capture path.
+- Saves are sparse: only settings you explicitly changed are written, so future default changes still reach
+  your installation. Unset fields display their built-in default. An existing file is backed up to
+  `<name>.bak` first, and unknown keys (such as `_comment` annotations) are preserved.
+- `--configure --config <path>` edits (or creates) a specific file; without `--config` the daemon's normal
+  search locations are used.
+
+After saving, restart mqttaudio to apply the changes.
 
 ## Configuration File
 

--- a/src/audio/engine.rs
+++ b/src/audio/engine.rs
@@ -10,31 +10,23 @@ use std::sync::Arc;
 
 /// List available audio output devices
 pub fn list_devices() {
-    #[cfg(target_os = "linux")]
-    {
-        list_devices_linux();
-    }
-
-    #[cfg(not(target_os = "linux"))]
-    {
-        list_devices_cpal_only();
-    }
-}
-
-/// Linux-specific device listing with ALSA probing
-#[cfg(target_os = "linux")]
-fn list_devices_linux() {
-    use super::alsa_probe::probe_alsa_devices;
     use super::device::format_device_list;
 
-    let list = probe_alsa_devices();
-    print!("{}", format_device_list(&list));
+    print!("{}", format_device_list(&output_device_list()));
 }
 
-/// Fallback device listing using only cpal (for macOS, Windows, etc.)
+/// Enumerate output devices with their capabilities. On Linux this probes ALSA
+/// directly for native hardware capabilities; elsewhere it queries cpal.
+#[cfg(target_os = "linux")]
+pub fn output_device_list() -> super::device::DeviceList {
+    super::alsa_probe::probe_alsa_devices()
+}
+
+/// Enumerate output devices with their capabilities. On Linux this probes ALSA
+/// directly for native hardware capabilities; elsewhere it queries cpal.
 #[cfg(not(target_os = "linux"))]
-fn list_devices_cpal_only() {
-    use super::device::{format_device_list, DeviceCategory, DeviceInfo, DeviceList};
+pub fn output_device_list() -> super::device::DeviceList {
+    use super::device::{DeviceCategory, DeviceInfo, DeviceList};
 
     let host = cpal::default_host();
     let mut list = DeviceList::new();
@@ -90,7 +82,7 @@ fn list_devices_cpal_only() {
         }
     }
 
-    print!("{}", format_device_list(&list));
+    list
 }
 
 /// Get default device configuration

--- a/src/audio/input.rs
+++ b/src/audio/input.rs
@@ -7,69 +7,153 @@ use ringbuf::{HeapConsumer, HeapProducer, HeapRb};
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
-/// List available audio input devices
-pub fn list_input_devices() {
+/// Capabilities of an input device, as far as they could be determined.
+pub enum InputCaps {
+    /// Capabilities probed from the device's supported configurations.
+    Probed {
+        max_channels: u16,
+        /// Unique (min, max) sample-rate ranges across the supported configurations.
+        sample_rates: Vec<(u32, u32)>,
+    },
+    /// All supported configurations were implausible (ALSA plugin devices report
+    /// fake rates), so this reflects the default configuration instead.
+    PluginFallback { channels: u16, sample_rate: u32 },
+    /// Supported configurations could not be enumerated; this reflects the
+    /// default configuration.
+    DefaultOnly { channels: u16, sample_rate: u32 },
+    /// No capability information could be obtained.
+    Unknown,
+}
+
+/// An input device discovered by enumeration.
+pub struct InputDeviceInfo {
+    /// Device name (used for the `inputs[].device` config field)
+    pub name: String,
+    pub caps: InputCaps,
+}
+
+impl InputDeviceInfo {
+    /// Channel count from whichever capability source was available, if any.
+    pub fn channels(&self) -> Option<u16> {
+        match self.caps {
+            InputCaps::Probed { max_channels, .. } => Some(max_channels),
+            InputCaps::PluginFallback { channels, .. } => Some(channels),
+            InputCaps::DefaultOnly { channels, .. } => Some(channels),
+            InputCaps::Unknown => None,
+        }
+    }
+}
+
+/// Enumerate available audio input devices with their capabilities.
+/// Errors during enumeration are returned as Err with a description.
+pub fn input_device_list() -> Result<Vec<InputDeviceInfo>, String> {
     let host = cpal::default_host();
 
+    let devices = host.input_devices().map_err(|e| e.to_string())?;
+    let mut list = Vec::new();
+    for device in devices {
+        let Ok(name) = device.description().map(|d| d.name().to_string()) else {
+            continue;
+        };
+
+        // Query all supported configs to find max channels
+        let caps = if let Ok(configs) = device.supported_input_configs() {
+            let mut max_channels = 0u16;
+            let mut sample_rates: Vec<(u32, u32)> = Vec::new();
+
+            // Filter configs: ignore those with absurd sample rates
+            // (ALSA plugins report 4294967295 Hz which is clearly fake)
+            const MAX_REASONABLE_SAMPLE_RATE: u32 = 384000;
+
+            for config in configs {
+                let max_rate = config.max_sample_rate();
+                // Skip configs from ALSA plugins that claim unrealistic capabilities
+                if max_rate > MAX_REASONABLE_SAMPLE_RATE {
+                    continue;
+                }
+
+                max_channels = max_channels.max(config.channels());
+                let min_rate = config.min_sample_rate();
+                // Collect unique sample rate ranges
+                if !sample_rates
+                    .iter()
+                    .any(|(min, max)| *min == min_rate && *max == max_rate)
+                {
+                    sample_rates.push((min_rate, max_rate));
+                }
+            }
+
+            if max_channels > 0 {
+                InputCaps::Probed {
+                    max_channels,
+                    sample_rates,
+                }
+            } else if let Ok(config) = device.default_input_config() {
+                // All configs were filtered out - fall back to default
+                // This happens with ALSA plugin devices
+                InputCaps::PluginFallback {
+                    channels: config.channels(),
+                    sample_rate: config.sample_rate(),
+                }
+            } else {
+                InputCaps::Unknown
+            }
+        } else if let Ok(config) = device.default_input_config() {
+            // Fallback to default config if supported_input_configs fails
+            InputCaps::DefaultOnly {
+                channels: config.channels(),
+                sample_rate: config.sample_rate(),
+            }
+        } else {
+            InputCaps::Unknown
+        };
+
+        list.push(InputDeviceInfo { name, caps });
+    }
+    Ok(list)
+}
+
+/// List available audio input devices
+pub fn list_input_devices() {
     println!("Available audio input devices:");
-    match host.input_devices() {
+    match input_device_list() {
         Ok(devices) => {
-            for (i, device) in devices.enumerate() {
-                if let Ok(name) = device.description().map(|d| d.name().to_string()) {
-                    println!("  {}. {}", i, name);
-
-                    // Query all supported configs to find max channels
-                    if let Ok(configs) = device.supported_input_configs() {
-                        let mut max_channels = 0u16;
-                        let mut sample_rates: Vec<(u32, u32)> = Vec::new();
-
-                        // Filter configs: ignore those with absurd sample rates
-                        // (ALSA plugins report 4294967295 Hz which is clearly fake)
-                        const MAX_REASONABLE_SAMPLE_RATE: u32 = 384000;
-
-                        for config in configs {
-                            let max_rate = config.max_sample_rate();
-                            // Skip configs from ALSA plugins that claim unrealistic capabilities
-                            if max_rate > MAX_REASONABLE_SAMPLE_RATE {
-                                continue;
+            for (i, device) in devices.iter().enumerate() {
+                println!("  {}. {}", i, device.name);
+                match &device.caps {
+                    InputCaps::Probed {
+                        max_channels,
+                        sample_rates,
+                    } => {
+                        // Show sample rate range(s)
+                        if sample_rates.len() == 1 {
+                            let (min, max) = sample_rates[0];
+                            if min == max {
+                                println!("     Sample rate: {} Hz", min);
+                            } else {
+                                println!("     Sample rate: {}-{} Hz", min, max);
                             }
-
-                            max_channels = max_channels.max(config.channels());
-                            let min_rate = config.min_sample_rate();
-                            // Collect unique sample rate ranges
-                            if !sample_rates
-                                .iter()
-                                .any(|(min, max)| *min == min_rate && *max == max_rate)
-                            {
-                                sample_rates.push((min_rate, max_rate));
-                            }
+                        } else if !sample_rates.is_empty() {
+                            // Multiple ranges, just show common rates
+                            println!("     Sample rates: (multiple configurations)");
                         }
-
-                        if max_channels > 0 {
-                            // Show sample rate range(s)
-                            if sample_rates.len() == 1 {
-                                let (min, max) = sample_rates[0];
-                                if min == max {
-                                    println!("     Sample rate: {} Hz", min);
-                                } else {
-                                    println!("     Sample rate: {}-{} Hz", min, max);
-                                }
-                            } else if !sample_rates.is_empty() {
-                                // Multiple ranges, just show common rates
-                                println!("     Sample rates: (multiple configurations)");
-                            }
-                            println!("     Max channels: {}", max_channels);
-                        } else if let Ok(config) = device.default_input_config() {
-                            // All configs were filtered out - fall back to default
-                            // This happens with ALSA plugin devices
-                            println!("     Sample rate: {} Hz (plugin)", config.sample_rate());
-                            println!("     Channels: {} (plugin)", config.channels());
-                        }
-                    } else if let Ok(config) = device.default_input_config() {
-                        // Fallback to default config if supported_input_configs fails
-                        println!("     Sample rate: {} Hz", config.sample_rate());
-                        println!("     Channels: {}", config.channels());
+                        println!("     Max channels: {}", max_channels);
                     }
+                    InputCaps::PluginFallback {
+                        channels,
+                        sample_rate,
+                    } => {
+                        println!("     Sample rate: {} Hz (plugin)", sample_rate);
+                        println!("     Channels: {} (plugin)", channels);
+                    }
+                    InputCaps::DefaultOnly {
+                        channels,
+                        sample_rate,
+                    } => {
+                        println!("     Sample rate: {} Hz", sample_rate);
+                        println!("     Channels: {}", channels);
+                    }
+                    InputCaps::Unknown => {}
                 }
             }
         }

--- a/src/config_editor/app.rs
+++ b/src/config_editor/app.rs
@@ -1,0 +1,1401 @@
+// ABOUTME: Application state and key handling for the interactive config editor.
+// ABOUTME: Drives section navigation, field editing, modals, and live device tests.
+
+use super::device_test::{
+    start_input_test, start_output_test, InputTestSession, OutputTestSession, BASS_TONE_HZ,
+    TEST_TONE_HZ, TONE_DURATION_MS,
+};
+use super::fields::{
+    default_config_value, display_value, parse_field_value, path_of, section_fields,
+    ConfigDocument, FieldKind, Section, Seg, SubFieldSpec,
+};
+use super::save::{save_document, save_path_candidates};
+use crate::config::{Config, InputConfig, MemoryBudget};
+use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
+use serde_json::Value;
+use std::path::PathBuf;
+use std::time::Instant;
+
+/// Which pane has keyboard focus.
+#[derive(Clone, Copy, PartialEq)]
+pub enum Pane {
+    Sidebar,
+    Form,
+}
+
+/// What a nested editing level shows.
+pub enum LevelKind {
+    /// A top-level section's form.
+    Section(Section),
+    /// A struct's fields (one ducking rule, one input, one route).
+    SubForm {
+        specs: &'static [SubFieldSpec],
+        defaults: Value,
+    },
+    /// A list of strings (precache, allowed_directories, ducked_voices).
+    StringList,
+    /// A list of channel references (bass_management.source_channels).
+    ChannelRefList,
+    /// A map with values of `value_kind` (aliases, volumes, macros).
+    Map { value_kind: FieldKind },
+    /// A list of structs (ducking_rules, inputs, routes).
+    StructList {
+        specs: &'static [SubFieldSpec],
+        item_label: &'static str,
+    },
+}
+
+/// One level of the editing stack: a form or collection at a JSON path.
+pub struct Level {
+    pub title: String,
+    pub path: Vec<Seg>,
+    pub kind: LevelKind,
+    pub cursor: usize,
+}
+
+/// One selectable row of the current level.
+pub struct Row {
+    pub label: String,
+    pub path: Vec<Seg>,
+    pub kind: FieldKind,
+    pub help: String,
+    pub display: String,
+    pub is_set: bool,
+}
+
+/// What an in-progress text edit will do when committed.
+pub enum EditTarget {
+    /// Set (or unset, for optional kinds) the field at `path`.
+    Field { path: Vec<Seg>, kind: FieldKind },
+    /// Append a new element to the list at `base`.
+    NewListItem { base: Vec<Seg>, kind: FieldKind },
+    /// First step of adding a map entry: the key. Commits into a `MapValue` edit.
+    MapKey {
+        base: Vec<Seg>,
+        value_kind: FieldKind,
+    },
+    /// Set the map value at `path` (an existing or just-named key).
+    MapValue { path: Vec<Seg>, kind: FieldKind },
+}
+
+/// An in-progress single-line text edit.
+pub struct EditState {
+    pub label: String,
+    pub buffer: String,
+    pub cursor: usize,
+    pub target: EditTarget,
+    pub error: Option<String>,
+}
+
+/// One entry in the device picker.
+pub struct PickerItem {
+    /// Device name to store in the config; None = system default.
+    pub name: Option<String>,
+    pub detail: String,
+}
+
+/// Live output test screen state.
+pub struct OutputTestState {
+    pub session: Option<OutputTestSession>,
+    pub error: Option<String>,
+    pub cursor: usize,
+    /// All-channels sweep: (next channel to play, time of the last play).
+    pub sweep: Option<(usize, Instant)>,
+    pub device_label: String,
+    /// idx -> alias name, from audio.channel_aliases.
+    pub aliases: Vec<Option<String>>,
+    /// Reopen this picker when the test screen closes.
+    pub return_to_picker: Option<(bool, Vec<Seg>)>,
+}
+
+/// Live input level-meter screen state.
+pub struct InputTestState {
+    pub session: Option<InputTestSession>,
+    pub error: Option<String>,
+    pub device_label: String,
+    pub return_to_picker: Option<(bool, Vec<Seg>)>,
+}
+
+/// A blocking overlay.
+pub enum Modal {
+    DevicePicker {
+        output: bool,
+        items: Vec<PickerItem>,
+        cursor: usize,
+        target: Vec<Seg>,
+    },
+    OutputTest(OutputTestState),
+    InputTest(InputTestState),
+    SaveDialog {
+        buffer: String,
+        cursor: usize,
+        candidates: Vec<PathBuf>,
+    },
+    Errors {
+        title: String,
+        errors: Vec<String>,
+    },
+    ConfirmQuit,
+    LoadFailed {
+        path: PathBuf,
+        error: String,
+    },
+}
+
+/// The whole editor's state.
+pub struct App {
+    pub doc: ConfigDocument,
+    pub defaults: Value,
+    pub loaded_from: Option<PathBuf>,
+    pub dirty: bool,
+    pub section_idx: usize,
+    pub pane: Pane,
+    pub levels: Vec<Level>,
+    pub edit: Option<EditState>,
+    pub modal: Option<Modal>,
+    pub status: String,
+    pub quit: bool,
+}
+
+impl App {
+    pub fn new(doc: ConfigDocument, loaded_from: Option<PathBuf>) -> Self {
+        let status = match &loaded_from {
+            Some(p) => format!("Editing {}", p.display()),
+            None => "New configuration (no file found)".to_string(),
+        };
+        Self {
+            doc,
+            defaults: default_config_value(),
+            loaded_from,
+            dirty: false,
+            section_idx: 0,
+            pane: Pane::Sidebar,
+            levels: vec![Level {
+                title: Section::ALL[0].title().to_string(),
+                path: Vec::new(),
+                kind: LevelKind::Section(Section::ALL[0]),
+                cursor: 0,
+            }],
+            edit: None,
+            modal: None,
+            status,
+            quit: false,
+        }
+    }
+
+    pub fn current_section(&self) -> Section {
+        Section::ALL[self.section_idx]
+    }
+
+    fn reset_levels(&mut self) {
+        let section = self.current_section();
+        self.levels = vec![Level {
+            title: section.title().to_string(),
+            path: Vec::new(),
+            kind: LevelKind::Section(section),
+            cursor: 0,
+        }];
+    }
+
+    fn level(&self) -> &Level {
+        self.levels.last().expect("levels is never empty")
+    }
+
+    fn level_mut(&mut self) -> &mut Level {
+        self.levels.last_mut().expect("levels is never empty")
+    }
+
+    /// The breadcrumb title for the content pane.
+    pub fn breadcrumb(&self) -> String {
+        self.levels
+            .iter()
+            .map(|l| l.title.as_str())
+            .collect::<Vec<_>>()
+            .join(" > ")
+    }
+
+    /// The default value at a static path under `Config::default()`.
+    fn default_at(&self, path: &[Seg]) -> Value {
+        let mut cur = &self.defaults;
+        for seg in path {
+            match seg {
+                Seg::Key(k) => match cur.as_object().and_then(|o| o.get(k)) {
+                    Some(v) => cur = v,
+                    None => return Value::Null,
+                },
+                Seg::Idx(_) => return Value::Null,
+            }
+        }
+        cur.clone()
+    }
+
+    /// The effective value at `path` (explicit or default) and whether it was
+    /// explicitly set.
+    fn effective(&self, path: &[Seg]) -> (Value, bool) {
+        match self.doc.get(path) {
+            Some(v) => (v.clone(), true),
+            None => (self.default_at(path), false),
+        }
+    }
+
+    /// Compute the rows of the current level.
+    pub fn rows(&self) -> Vec<Row> {
+        let level = self.level();
+        match &level.kind {
+            LevelKind::Section(section) => {
+                let mut rows = Vec::new();
+                for spec in section_fields(*section) {
+                    let path = path_of(spec.path);
+                    let (value, is_set) = self.effective(&path);
+                    rows.push(Row {
+                        label: spec.label.to_string(),
+                        display: display_value(&spec.kind, &value),
+                        path,
+                        kind: spec.kind,
+                        help: spec.help.to_string(),
+                        is_set,
+                    });
+                    // The memory budget's mode-specific parameters appear as
+                    // extra rows right below it.
+                    if spec.kind == FieldKind::MemoryBudget {
+                        self.push_memory_budget_rows(&mut rows, spec.path);
+                    }
+                }
+                rows
+            }
+            LevelKind::SubForm { specs, defaults } => specs
+                .iter()
+                .map(|spec| {
+                    let mut path = level.path.clone();
+                    path.push(Seg::Key(spec.key.to_string()));
+                    let (value, is_set) = match self.doc.get(&path) {
+                        Some(v) => (v.clone(), true),
+                        None => (
+                            defaults
+                                .as_object()
+                                .and_then(|o| o.get(spec.key))
+                                .cloned()
+                                .unwrap_or(Value::Null),
+                            false,
+                        ),
+                    };
+                    Row {
+                        label: spec.label.to_string(),
+                        display: display_value(&spec.kind, &value),
+                        path,
+                        kind: spec.kind,
+                        help: spec.help.to_string(),
+                        is_set,
+                    }
+                })
+                .collect(),
+            LevelKind::StringList | LevelKind::ChannelRefList => {
+                let kind = if matches!(level.kind, LevelKind::StringList) {
+                    FieldKind::Text
+                } else {
+                    FieldKind::ChannelRef
+                };
+                self.list_values(&level.path)
+                    .iter()
+                    .enumerate()
+                    .map(|(i, v)| {
+                        let mut path = level.path.clone();
+                        path.push(Seg::Idx(i));
+                        Row {
+                            label: format!("{}", i + 1),
+                            display: display_value(&kind, v),
+                            path,
+                            kind,
+                            help: "Enter: edit   a: add   d/Del: remove".to_string(),
+                            is_set: true,
+                        }
+                    })
+                    .collect()
+            }
+            LevelKind::Map { value_kind } => {
+                let mut rows: Vec<Row> = Vec::new();
+                if let Some(Value::Object(map)) = self.doc.get(&level.path) {
+                    let mut keys: Vec<&String> = map.keys().collect();
+                    keys.sort();
+                    for key in keys {
+                        let mut path = level.path.clone();
+                        path.push(Seg::Key(key.clone()));
+                        let value = &map[key];
+                        let display = match value_kind {
+                            FieldKind::MapToJson => {
+                                serde_json::to_string(value).unwrap_or_default()
+                            }
+                            _ => display_value(value_kind, value),
+                        };
+                        rows.push(Row {
+                            label: key.clone(),
+                            display,
+                            path,
+                            kind: *value_kind,
+                            help: "Enter: edit value   a: add entry   d/Del: remove".to_string(),
+                            is_set: true,
+                        });
+                    }
+                }
+                rows
+            }
+            LevelKind::StructList { specs, item_label } => self
+                .list_values(&level.path)
+                .iter()
+                .enumerate()
+                .map(|(i, v)| {
+                    let mut path = level.path.clone();
+                    path.push(Seg::Idx(i));
+                    Row {
+                        label: format!("{} {}", item_label, i + 1),
+                        display: summarize_struct(v, specs),
+                        path,
+                        kind: FieldKind::StructList(specs),
+                        help: "Enter: edit   a: add   d/Del: remove".to_string(),
+                        is_set: true,
+                    }
+                })
+                .collect(),
+        }
+    }
+
+    fn list_values(&self, path: &[Seg]) -> Vec<Value> {
+        match self.doc.get(path) {
+            Some(Value::Array(arr)) => arr.clone(),
+            _ => Vec::new(),
+        }
+    }
+
+    fn push_memory_budget_rows(&self, rows: &mut Vec<Row>, base: &[&str]) {
+        let base_path = path_of(base);
+        let Some(Value::Object(budget)) = self.doc.get(&base_path) else {
+            return;
+        };
+        let auto_defaults =
+            serde_json::to_value(MemoryBudget::default_auto()).unwrap_or(Value::Null);
+        let mode = budget.get("mode").and_then(|m| m.as_str()).unwrap_or("");
+        let sub: &[(&str, FieldKind, &str)] = match mode {
+            "auto" => &[
+                (
+                    "fraction",
+                    FieldKind::Float { min: 0.0, max: 1.0 },
+                    "Fraction of available RAM to target. Default 0.4.",
+                ),
+                (
+                    "floor_mb",
+                    FieldKind::UInt {
+                        min: 1,
+                        max: u32::MAX as u64,
+                    },
+                    "Minimum cap in MiB, so small assets still cache on a tiny box. Default 128.",
+                ),
+                (
+                    "ceiling_mb",
+                    FieldKind::UInt {
+                        min: 1,
+                        max: u32::MAX as u64,
+                    },
+                    "Maximum cap in MiB, so the daemon never camps all RAM. Default 1024.",
+                ),
+            ],
+            "explicit" => &[(
+                "mb",
+                FieldKind::UInt {
+                    min: 1,
+                    max: u32::MAX as u64,
+                },
+                "Fixed memory cache cap in MiB.",
+            )],
+            _ => &[],
+        };
+        for (key, kind, help) in sub {
+            let mut path = base_path.clone();
+            path.push(Seg::Key(key.to_string()));
+            let (value, is_set) = match budget.get(*key) {
+                Some(v) => (v.clone(), true),
+                None => (
+                    auto_defaults
+                        .as_object()
+                        .and_then(|o| o.get(*key))
+                        .cloned()
+                        .unwrap_or(Value::Null),
+                    false,
+                ),
+            };
+            rows.push(Row {
+                label: format!("memory_budget.{}", key),
+                display: display_value(kind, &value),
+                path,
+                kind: *kind,
+                help: help.to_string(),
+                is_set,
+            });
+        }
+    }
+
+    /// Advance to the next state for one key press.
+    pub fn handle_key(&mut self, key: KeyEvent) {
+        if key.kind != KeyEventKind::Press {
+            return;
+        }
+        if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('c') {
+            self.request_quit();
+            return;
+        }
+        if self.modal.is_some() {
+            self.handle_modal_key(key);
+            return;
+        }
+        if self.edit.is_some() {
+            self.handle_edit_key(key);
+            return;
+        }
+        self.handle_normal_key(key);
+    }
+
+    fn request_quit(&mut self) {
+        if self.dirty {
+            self.modal = Some(Modal::ConfirmQuit);
+        } else {
+            self.quit = true;
+        }
+    }
+
+    fn handle_normal_key(&mut self, key: KeyEvent) {
+        match key.code {
+            KeyCode::Char('q') => self.request_quit(),
+            KeyCode::Char('s') => self.open_save_dialog(),
+            KeyCode::Tab => {
+                self.pane = match self.pane {
+                    Pane::Sidebar => Pane::Form,
+                    Pane::Form => Pane::Sidebar,
+                };
+            }
+            _ => match self.pane {
+                Pane::Sidebar => self.handle_sidebar_key(key),
+                Pane::Form => self.handle_form_key(key),
+            },
+        }
+    }
+
+    fn handle_sidebar_key(&mut self, key: KeyEvent) {
+        match key.code {
+            KeyCode::Up => {
+                if self.section_idx > 0 {
+                    self.section_idx -= 1;
+                    self.reset_levels();
+                }
+            }
+            KeyCode::Down => {
+                if self.section_idx + 1 < Section::ALL.len() {
+                    self.section_idx += 1;
+                    self.reset_levels();
+                }
+            }
+            KeyCode::Right | KeyCode::Enter => self.pane = Pane::Form,
+            _ => {}
+        }
+    }
+
+    fn handle_form_key(&mut self, key: KeyEvent) {
+        let row_count = self.rows().len();
+        match key.code {
+            KeyCode::Up => {
+                let level = self.level_mut();
+                level.cursor = level.cursor.saturating_sub(1);
+            }
+            KeyCode::Down => {
+                let level = self.level_mut();
+                if row_count > 0 && level.cursor + 1 < row_count {
+                    level.cursor += 1;
+                }
+            }
+            KeyCode::Left | KeyCode::Esc => {
+                if self.levels.len() > 1 {
+                    self.levels.pop();
+                } else {
+                    self.pane = Pane::Sidebar;
+                }
+            }
+            KeyCode::Enter | KeyCode::Char(' ') => self.activate_row(),
+            KeyCode::Delete | KeyCode::Char('u') => self.unset_row(),
+            KeyCode::Char('d') => {
+                if self.level_is_collection() {
+                    self.unset_row();
+                }
+            }
+            KeyCode::Char('a') => self.add_to_collection(),
+            _ => {}
+        }
+    }
+
+    fn level_is_collection(&self) -> bool {
+        matches!(
+            self.level().kind,
+            LevelKind::StringList
+                | LevelKind::ChannelRefList
+                | LevelKind::Map { .. }
+                | LevelKind::StructList { .. }
+        )
+    }
+
+    /// Enter/space on the highlighted row.
+    fn activate_row(&mut self) {
+        let rows = self.rows();
+        let cursor = self.level().cursor;
+        let Some(row) = rows.get(cursor) else {
+            // Empty collection: Enter adds the first entry.
+            if self.level_is_collection() {
+                self.add_to_collection();
+            }
+            return;
+        };
+        let in_map = matches!(self.level().kind, LevelKind::Map { .. });
+        match row.kind {
+            FieldKind::Bool => {
+                let (value, _) = self.effective(&row.path);
+                let current = value.as_bool().unwrap_or(false);
+                self.doc.set(&row.path, Value::Bool(!current));
+                self.dirty = true;
+            }
+            FieldKind::Flag => {
+                if self.doc.get(&row.path).is_some() {
+                    self.doc.unset(&row.path);
+                } else {
+                    self.doc
+                        .set(&row.path, Value::Object(serde_json::Map::new()));
+                }
+                self.dirty = true;
+            }
+            FieldKind::Enum(options) => {
+                let (value, _) = self.effective(&row.path);
+                let current = value.as_str().unwrap_or("");
+                let idx = options.iter().position(|o| *o == current);
+                let next = options[(idx.map(|i| i + 1).unwrap_or(0)) % options.len()];
+                self.doc.set(&row.path, Value::String(next.to_string()));
+                self.dirty = true;
+            }
+            FieldKind::MemoryBudget => {
+                self.cycle_memory_budget(&row.path);
+            }
+            FieldKind::OutputDevice => self.open_device_picker(true, row.path.clone()),
+            FieldKind::InputDevice => self.open_device_picker(false, row.path.clone()),
+            FieldKind::StringList => self.push_level(Level {
+                title: row.label.clone(),
+                path: row.path.clone(),
+                kind: LevelKind::StringList,
+                cursor: 0,
+            }),
+            FieldKind::ChannelRefList => self.push_level(Level {
+                title: row.label.clone(),
+                path: row.path.clone(),
+                kind: LevelKind::ChannelRefList,
+                cursor: 0,
+            }),
+            FieldKind::MapToUInt => self.push_level(Level {
+                title: row.label.clone(),
+                path: row.path.clone(),
+                kind: LevelKind::Map {
+                    value_kind: FieldKind::UInt { min: 0, max: 65535 },
+                },
+                cursor: 0,
+            }),
+            FieldKind::MapToFloat { min, max } => self.push_level(Level {
+                title: row.label.clone(),
+                path: row.path.clone(),
+                kind: LevelKind::Map {
+                    value_kind: FieldKind::Float { min, max },
+                },
+                cursor: 0,
+            }),
+            FieldKind::MapToJson if !in_map => self.push_level(Level {
+                title: row.label.clone(),
+                path: row.path.clone(),
+                kind: LevelKind::Map {
+                    value_kind: FieldKind::MapToJson,
+                },
+                cursor: 0,
+            }),
+            FieldKind::StructList(specs) => {
+                if matches!(self.level().kind, LevelKind::StructList { .. }) {
+                    // A list item row: open its sub-form.
+                    self.open_subform(row.path.clone(), specs, row.label.clone());
+                } else {
+                    // A field row pointing at a struct list: open the list.
+                    let item_label = struct_item_label(specs);
+                    self.push_level(Level {
+                        title: row.label.clone(),
+                        path: row.path.clone(),
+                        kind: LevelKind::StructList { specs, item_label },
+                        cursor: 0,
+                    });
+                }
+            }
+            _ => self.start_field_edit(row),
+        }
+    }
+
+    fn start_field_edit(&mut self, row: &Row) {
+        let buffer = match row.kind {
+            FieldKind::Secret => String::new(),
+            FieldKind::MapToJson => self
+                .doc
+                .get(&row.path)
+                .map(|v| serde_json::to_string(v).unwrap_or_default())
+                .unwrap_or_default(),
+            _ => match self.doc.get(&row.path) {
+                Some(Value::String(s)) => s.clone(),
+                Some(v) => v.to_string(),
+                None => String::new(),
+            },
+        };
+        let target = if matches!(self.level().kind, LevelKind::Map { .. }) {
+            EditTarget::MapValue {
+                path: row.path.clone(),
+                kind: row.kind,
+            }
+        } else if matches!(
+            self.level().kind,
+            LevelKind::StringList | LevelKind::ChannelRefList
+        ) {
+            EditTarget::Field {
+                path: row.path.clone(),
+                kind: row.kind,
+            }
+        } else {
+            EditTarget::Field {
+                path: row.path.clone(),
+                kind: row.kind,
+            }
+        };
+        self.edit = Some(EditState {
+            label: row.label.clone(),
+            cursor: buffer.chars().count(),
+            buffer,
+            target,
+            error: None,
+        });
+    }
+
+    fn cycle_memory_budget(&mut self, path: &[Seg]) {
+        let mode = self
+            .doc
+            .get(path)
+            .and_then(|v| v.get("mode"))
+            .and_then(|m| m.as_str())
+            .map(|s| s.to_string());
+        match mode.as_deref() {
+            None => {
+                self.doc.set(path, serde_json::json!({ "mode": "auto" }));
+            }
+            Some("auto") => {
+                self.doc
+                    .set(path, serde_json::json!({ "mode": "explicit", "mb": 512 }));
+            }
+            Some("explicit") => {
+                self.doc
+                    .set(path, serde_json::json!({ "mode": "unlimited" }));
+            }
+            _ => self.doc.unset(path),
+        }
+        self.dirty = true;
+    }
+
+    fn push_level(&mut self, level: Level) {
+        self.levels.push(level);
+    }
+
+    fn open_subform(&mut self, path: Vec<Seg>, specs: &'static [SubFieldSpec], title: String) {
+        let defaults = if std::ptr::eq(specs.as_ptr(), super::fields::INPUT_FIELDS.as_ptr()) {
+            serde_json::to_value(InputConfig::default()).unwrap_or(Value::Null)
+        } else {
+            Value::Null
+        };
+        self.push_level(Level {
+            title,
+            path,
+            kind: LevelKind::SubForm { specs, defaults },
+            cursor: 0,
+        });
+    }
+
+    /// Del/'u' on the highlighted row: unset a field or remove a collection entry.
+    fn unset_row(&mut self) {
+        let rows = self.rows();
+        let cursor = self.level().cursor;
+        let Some(row) = rows.get(cursor) else {
+            return;
+        };
+        self.doc.unset(&row.path);
+        self.dirty = true;
+        let row_count = self.rows().len();
+        let level = self.level_mut();
+        if level.cursor >= row_count && level.cursor > 0 {
+            level.cursor -= 1;
+        }
+    }
+
+    /// 'a' in a collection level: add an entry.
+    fn add_to_collection(&mut self) {
+        enum Add {
+            Item(FieldKind, &'static str),
+            MapEntry(FieldKind),
+            Struct(&'static [SubFieldSpec], &'static str),
+            None,
+        }
+        let path = self.level().path.clone();
+        let action = match &self.level().kind {
+            LevelKind::StringList => Add::Item(FieldKind::Text, "new entry"),
+            LevelKind::ChannelRefList => {
+                Add::Item(FieldKind::ChannelRef, "new channel (number or alias)")
+            }
+            LevelKind::Map { value_kind } => Add::MapEntry(*value_kind),
+            LevelKind::StructList { specs, item_label } => Add::Struct(specs, item_label),
+            _ => Add::None,
+        };
+        match action {
+            Add::Item(kind, label) => {
+                self.edit = Some(EditState {
+                    label: label.to_string(),
+                    buffer: String::new(),
+                    cursor: 0,
+                    target: EditTarget::NewListItem { base: path, kind },
+                    error: None,
+                });
+            }
+            Add::MapEntry(value_kind) => {
+                self.edit = Some(EditState {
+                    label: "new key".to_string(),
+                    buffer: String::new(),
+                    cursor: 0,
+                    target: EditTarget::MapKey {
+                        base: path,
+                        value_kind,
+                    },
+                    error: None,
+                });
+            }
+            Add::Struct(specs, item_label) => {
+                let skeleton = struct_skeleton(specs);
+                self.doc.push(&path, skeleton);
+                self.dirty = true;
+                let idx = self.doc.list_len(&path) - 1;
+                let title = format!("{} {}", item_label, idx + 1);
+                let mut item_path = path;
+                item_path.push(Seg::Idx(idx));
+                self.open_subform(item_path, specs, title);
+            }
+            Add::None => {}
+        }
+    }
+
+    fn handle_edit_key(&mut self, key: KeyEvent) {
+        let Some(edit) = self.edit.as_mut() else {
+            return;
+        };
+        match key.code {
+            KeyCode::Esc => self.edit = None,
+            KeyCode::Enter => self.commit_edit(),
+            KeyCode::Char(c) => {
+                let byte = byte_index(&edit.buffer, edit.cursor);
+                edit.buffer.insert(byte, c);
+                edit.cursor += 1;
+            }
+            KeyCode::Backspace => {
+                if edit.cursor > 0 {
+                    edit.cursor -= 1;
+                    let byte = byte_index(&edit.buffer, edit.cursor);
+                    edit.buffer.remove(byte);
+                }
+            }
+            KeyCode::Delete => {
+                if edit.cursor < edit.buffer.chars().count() {
+                    let byte = byte_index(&edit.buffer, edit.cursor);
+                    edit.buffer.remove(byte);
+                }
+            }
+            KeyCode::Left => edit.cursor = edit.cursor.saturating_sub(1),
+            KeyCode::Right => {
+                if edit.cursor < edit.buffer.chars().count() {
+                    edit.cursor += 1;
+                }
+            }
+            KeyCode::Home => edit.cursor = 0,
+            KeyCode::End => edit.cursor = edit.buffer.chars().count(),
+            _ => {}
+        }
+    }
+
+    fn commit_edit(&mut self) {
+        let Some(edit) = self.edit.take() else {
+            return;
+        };
+        match edit.target {
+            EditTarget::Field { ref path, ref kind } => {
+                match parse_field_value(kind, &edit.buffer) {
+                    Ok(Some(v)) => {
+                        self.doc.set(path, v);
+                        self.dirty = true;
+                    }
+                    Ok(None) => {
+                        self.doc.unset(path);
+                        self.dirty = true;
+                    }
+                    Err(e) => {
+                        self.edit = Some(EditState {
+                            error: Some(e),
+                            ..edit
+                        });
+                    }
+                }
+            }
+            EditTarget::NewListItem { ref base, ref kind } => {
+                match parse_field_value(kind, &edit.buffer) {
+                    Ok(Some(v)) => {
+                        self.doc.push(base, v);
+                        self.dirty = true;
+                        let count = self.doc.list_len(base);
+                        self.level_mut().cursor = count.saturating_sub(1);
+                    }
+                    Ok(None) => {}
+                    Err(e) => {
+                        self.edit = Some(EditState {
+                            error: Some(e),
+                            ..edit
+                        });
+                    }
+                }
+            }
+            EditTarget::MapKey {
+                ref base,
+                ref value_kind,
+            } => {
+                let key = edit.buffer.trim().to_string();
+                if key.is_empty() {
+                    self.edit = Some(EditState {
+                        error: Some("a key is required".to_string()),
+                        ..edit
+                    });
+                    return;
+                }
+                let mut path = base.clone();
+                path.push(Seg::Key(key.clone()));
+                if self.doc.get(&path).is_some() {
+                    self.edit = Some(EditState {
+                        error: Some(format!("'{}' already exists", key)),
+                        ..edit
+                    });
+                    return;
+                }
+                self.edit = Some(EditState {
+                    label: format!("value for {}", key),
+                    buffer: String::new(),
+                    cursor: 0,
+                    target: EditTarget::MapValue {
+                        path,
+                        kind: *value_kind,
+                    },
+                    error: None,
+                });
+            }
+            EditTarget::MapValue { ref path, ref kind } => {
+                match parse_field_value(kind, &edit.buffer) {
+                    Ok(Some(v)) => {
+                        self.doc.set(path, v);
+                        self.dirty = true;
+                    }
+                    Ok(None) => {
+                        self.edit = Some(EditState {
+                            error: Some("a value is required".to_string()),
+                            ..edit
+                        });
+                    }
+                    Err(e) => {
+                        self.edit = Some(EditState {
+                            error: Some(e),
+                            ..edit
+                        });
+                    }
+                }
+            }
+        }
+    }
+
+    fn open_save_dialog(&mut self) {
+        let candidates = save_path_candidates(self.loaded_from.as_deref());
+        let buffer = candidates
+            .first()
+            .map(|p| p.display().to_string())
+            .unwrap_or_else(|| "./mqttaudio.json".to_string());
+        self.modal = Some(Modal::SaveDialog {
+            cursor: buffer.chars().count(),
+            buffer,
+            candidates,
+        });
+    }
+
+    fn open_device_picker(&mut self, output: bool, target: Vec<Seg>) {
+        let mut items = vec![PickerItem {
+            name: None,
+            detail: "use the system default device".to_string(),
+        }];
+        if output {
+            let list = crate::audio::engine::output_device_list();
+            for d in &list.devices {
+                let mut detail = d.category.to_string();
+                if let Some(ref caps) = d.native_capabilities {
+                    detail = format!(
+                        "{} | {} ch, {} Hz, {}",
+                        detail,
+                        caps.format_channels(),
+                        caps.format_rates(),
+                        caps.format_formats()
+                    );
+                } else if let (Some(ch), Some(min), Some(max)) = (
+                    d.cpal_channels,
+                    d.cpal_sample_rate_min,
+                    d.cpal_sample_rate_max,
+                ) {
+                    if min == max {
+                        detail = format!("{} | {} ch, {} Hz", detail, ch, min);
+                    } else {
+                        detail = format!("{} | {} ch, {}-{} Hz", detail, ch, min, max);
+                    }
+                }
+                if let Some(ref desc) = d.description {
+                    detail = format!("{} | {}", desc, detail);
+                }
+                items.push(PickerItem {
+                    name: Some(d.name.clone()),
+                    detail,
+                });
+            }
+        } else {
+            match crate::audio::input::input_device_list() {
+                Ok(list) => {
+                    for d in &list {
+                        let detail = match d.channels() {
+                            Some(ch) => format!("{} ch", ch),
+                            None => "capabilities unknown".to_string(),
+                        };
+                        items.push(PickerItem {
+                            name: Some(d.name.clone()),
+                            detail,
+                        });
+                    }
+                }
+                Err(e) => {
+                    self.status = format!("Could not list input devices: {}", e);
+                }
+            }
+        }
+        self.modal = Some(Modal::DevicePicker {
+            output,
+            items,
+            cursor: 0,
+            target,
+        });
+    }
+
+    /// The config the device test should run with: the in-progress document if
+    /// it deserializes, otherwise compiled-in defaults.
+    fn test_config(&mut self) -> Config {
+        match self.doc.to_config() {
+            Ok(c) => c,
+            Err(e) => {
+                self.status = format!("Config incomplete, testing with defaults: {}", e);
+                Config::default()
+            }
+        }
+    }
+
+    fn start_output_test_screen(
+        &mut self,
+        device_name: Option<String>,
+        return_to_picker: Option<(bool, Vec<Seg>)>,
+    ) {
+        let config = self.test_config();
+        let aliases_map = config.audio.channel_aliases.clone();
+        let (session, error) = match start_output_test(&config, device_name.as_deref()) {
+            Ok(s) => (Some(s), None),
+            Err(e) => (None, Some(e)),
+        };
+        let channels = session.as_ref().map(|s| s.channels).unwrap_or(0);
+        let mut aliases: Vec<Option<String>> = vec![None; channels];
+        for (name, idx) in &aliases_map {
+            if *idx < channels {
+                aliases[*idx] = Some(name.clone());
+            }
+        }
+        self.modal = Some(Modal::OutputTest(OutputTestState {
+            session,
+            error,
+            cursor: 0,
+            sweep: None,
+            device_label: device_name.unwrap_or_else(|| "(default)".to_string()),
+            aliases,
+            return_to_picker,
+        }));
+    }
+
+    fn start_input_test_screen(
+        &mut self,
+        device_name: Option<String>,
+        target: &[Seg],
+        return_to_picker: Option<(bool, Vec<Seg>)>,
+    ) {
+        let config = self.test_config();
+        // Use the latency configured on the input entry being edited (the
+        // picker's target path is .../device; latency_ms is its sibling).
+        let latency_ms = if target.len() >= 2 {
+            let mut sibling = target[..target.len() - 1].to_vec();
+            sibling.push(Seg::Key("latency_ms".to_string()));
+            self.doc
+                .get(&sibling)
+                .and_then(|v| v.as_u64())
+                .map(|v| v as u32)
+                .unwrap_or(20)
+        } else {
+            20
+        };
+        let (session, error) =
+            match start_input_test(device_name.as_deref(), latency_ms, config.audio.sample_rate) {
+                Ok(s) => (Some(s), None),
+                Err(e) => (None, Some(e)),
+            };
+        self.modal = Some(Modal::InputTest(InputTestState {
+            session,
+            error,
+            device_label: device_name.unwrap_or_else(|| "(default)".to_string()),
+            return_to_picker,
+        }));
+    }
+
+    fn handle_modal_key(&mut self, key: KeyEvent) {
+        let modal = self.modal.take();
+        match modal {
+            Some(Modal::DevicePicker {
+                output,
+                items,
+                mut cursor,
+                target,
+            }) => match key.code {
+                KeyCode::Esc | KeyCode::Char('q') => {}
+                KeyCode::Up => {
+                    cursor = cursor.saturating_sub(1);
+                    self.modal = Some(Modal::DevicePicker {
+                        output,
+                        items,
+                        cursor,
+                        target,
+                    });
+                }
+                KeyCode::Down => {
+                    if cursor + 1 < items.len() {
+                        cursor += 1;
+                    }
+                    self.modal = Some(Modal::DevicePicker {
+                        output,
+                        items,
+                        cursor,
+                        target,
+                    });
+                }
+                KeyCode::Enter => {
+                    match &items[cursor].name {
+                        Some(name) => {
+                            self.doc.set(&target, Value::String(name.clone()));
+                        }
+                        None => self.doc.unset(&target),
+                    }
+                    self.dirty = true;
+                    self.status = format!(
+                        "Device set to {}",
+                        items[cursor].name.as_deref().unwrap_or("(default)")
+                    );
+                }
+                KeyCode::Char('t') => {
+                    let name = items[cursor].name.clone();
+                    let back = Some((output, target.clone()));
+                    if output {
+                        self.start_output_test_screen(name, back);
+                    } else {
+                        self.start_input_test_screen(name, &target, back);
+                    }
+                }
+                _ => {
+                    self.modal = Some(Modal::DevicePicker {
+                        output,
+                        items,
+                        cursor,
+                        target,
+                    });
+                }
+            },
+            Some(Modal::OutputTest(mut state)) => match key.code {
+                KeyCode::Esc | KeyCode::Char('q') => {
+                    drop(state.session.take());
+                    if let Some((output, target)) = state.return_to_picker {
+                        self.open_device_picker(output, target);
+                    }
+                }
+                KeyCode::Up => {
+                    state.cursor = state.cursor.saturating_sub(1);
+                    self.modal = Some(Modal::OutputTest(state));
+                }
+                KeyCode::Down => {
+                    let channels = state.session.as_ref().map(|s| s.channels).unwrap_or(0);
+                    if state.cursor + 1 < channels {
+                        state.cursor += 1;
+                    }
+                    self.modal = Some(Modal::OutputTest(state));
+                }
+                KeyCode::Enter | KeyCode::Char(' ') => {
+                    let cursor = state.cursor;
+                    if let Some(session) = state.session.as_mut() {
+                        if let Err(e) = session.play_tone_on_channel(cursor, TEST_TONE_HZ) {
+                            state.error = Some(e);
+                        }
+                    }
+                    self.modal = Some(Modal::OutputTest(state));
+                }
+                KeyCode::Char('b') => {
+                    let cursor = state.cursor;
+                    if let Some(session) = state.session.as_mut() {
+                        if let Err(e) = session.play_tone_on_channel(cursor, BASS_TONE_HZ) {
+                            state.error = Some(e);
+                        }
+                    }
+                    self.modal = Some(Modal::OutputTest(state));
+                }
+                KeyCode::Char('a') => {
+                    state.sweep = Some((0, Instant::now() - sweep_interval()));
+                    self.modal = Some(Modal::OutputTest(state));
+                }
+                _ => self.modal = Some(Modal::OutputTest(state)),
+            },
+            Some(Modal::InputTest(mut state)) => match key.code {
+                KeyCode::Esc | KeyCode::Char('q') => {
+                    drop(state.session.take());
+                    if let Some((output, target)) = state.return_to_picker {
+                        self.open_device_picker(output, target);
+                    }
+                }
+                _ => self.modal = Some(Modal::InputTest(state)),
+            },
+            Some(Modal::SaveDialog {
+                mut buffer,
+                mut cursor,
+                candidates,
+            }) => match key.code {
+                KeyCode::Esc => {}
+                KeyCode::Enter => {
+                    let path = PathBuf::from(buffer.trim());
+                    match save_document(&self.doc, &path) {
+                        Ok(outcome) => {
+                            self.dirty = false;
+                            self.loaded_from = Some(path.clone());
+                            self.status = match outcome.backup {
+                                Some(bak) => format!(
+                                    "Saved {} (backup at {}) — restart mqttaudio to apply",
+                                    path.display(),
+                                    bak.display()
+                                ),
+                                None => {
+                                    format!("Saved {} — restart mqttaudio to apply", path.display())
+                                }
+                            };
+                        }
+                        Err(errors) => {
+                            self.modal = Some(Modal::Errors {
+                                title: "Cannot save: configuration is invalid".to_string(),
+                                errors,
+                            });
+                        }
+                    }
+                }
+                KeyCode::Up | KeyCode::Down => {
+                    let current = candidates
+                        .iter()
+                        .position(|c| c.display().to_string() == buffer);
+                    let next = match (key.code, current) {
+                        (KeyCode::Down, Some(i)) => (i + 1) % candidates.len(),
+                        (KeyCode::Up, Some(i)) => (i + candidates.len() - 1) % candidates.len(),
+                        _ => 0,
+                    };
+                    if let Some(c) = candidates.get(next) {
+                        buffer = c.display().to_string();
+                        cursor = buffer.chars().count();
+                    }
+                    self.modal = Some(Modal::SaveDialog {
+                        buffer,
+                        cursor,
+                        candidates,
+                    });
+                }
+                KeyCode::Char(c) => {
+                    let byte = byte_index(&buffer, cursor);
+                    buffer.insert(byte, c);
+                    cursor += 1;
+                    self.modal = Some(Modal::SaveDialog {
+                        buffer,
+                        cursor,
+                        candidates,
+                    });
+                }
+                KeyCode::Backspace => {
+                    if cursor > 0 {
+                        cursor -= 1;
+                        let byte = byte_index(&buffer, cursor);
+                        buffer.remove(byte);
+                    }
+                    self.modal = Some(Modal::SaveDialog {
+                        buffer,
+                        cursor,
+                        candidates,
+                    });
+                }
+                KeyCode::Left => {
+                    cursor = cursor.saturating_sub(1);
+                    self.modal = Some(Modal::SaveDialog {
+                        buffer,
+                        cursor,
+                        candidates,
+                    });
+                }
+                KeyCode::Right => {
+                    if cursor < buffer.chars().count() {
+                        cursor += 1;
+                    }
+                    self.modal = Some(Modal::SaveDialog {
+                        buffer,
+                        cursor,
+                        candidates,
+                    });
+                }
+                _ => {
+                    self.modal = Some(Modal::SaveDialog {
+                        buffer,
+                        cursor,
+                        candidates,
+                    });
+                }
+            },
+            Some(Modal::Errors { .. }) => {
+                // Any key dismisses.
+            }
+            Some(Modal::ConfirmQuit) => match key.code {
+                KeyCode::Char('y') | KeyCode::Char('Y') => self.quit = true,
+                _ => {}
+            },
+            Some(Modal::LoadFailed { path, error }) => match key.code {
+                KeyCode::Char('d') | KeyCode::Char('D') => {
+                    self.doc = ConfigDocument::new();
+                    self.status = format!(
+                        "Started from defaults; {} is untouched until you save",
+                        path.display()
+                    );
+                }
+                KeyCode::Char('q') | KeyCode::Esc => self.quit = true,
+                _ => self.modal = Some(Modal::LoadFailed { path, error }),
+            },
+            None => {}
+        }
+    }
+
+    /// Periodic work: drive device-test sessions and the channel sweep.
+    pub fn tick(&mut self) {
+        match self.modal.as_mut() {
+            Some(Modal::OutputTest(state)) => {
+                if let Some(session) = state.session.as_mut() {
+                    if let Err(e) = session.poll() {
+                        state.error = Some(e);
+                    }
+                    if let Some((next, last)) = state.sweep {
+                        if last.elapsed() >= sweep_interval() {
+                            if next < session.channels {
+                                state.cursor = next;
+                                if let Err(e) = session.play_tone_on_channel(next, TEST_TONE_HZ) {
+                                    state.error = Some(e);
+                                }
+                                state.sweep = Some((next + 1, Instant::now()));
+                            } else {
+                                state.sweep = None;
+                            }
+                        }
+                    }
+                }
+            }
+            Some(Modal::InputTest(state)) => {
+                if let Some(session) = state.session.as_mut() {
+                    session.poll();
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Gap between sweep tones: the tone itself plus a beat of silence.
+fn sweep_interval() -> std::time::Duration {
+    std::time::Duration::from_millis(TONE_DURATION_MS as u64 + 300)
+}
+
+/// Byte offset of character `cursor` in `s` (cursor positions are in chars).
+fn byte_index(s: &str, cursor: usize) -> usize {
+    s.char_indices()
+        .nth(cursor)
+        .map(|(i, _)| i)
+        .unwrap_or(s.len())
+}
+
+/// Display label for one item of a struct list.
+fn struct_item_label(specs: &'static [SubFieldSpec]) -> &'static str {
+    if std::ptr::eq(specs.as_ptr(), super::fields::INPUT_FIELDS.as_ptr()) {
+        "input"
+    } else if std::ptr::eq(specs.as_ptr(), super::fields::INPUT_ROUTE_FIELDS.as_ptr()) {
+        "route"
+    } else {
+        "rule"
+    }
+}
+
+/// A new list item that deserializes: structs whose fields are all required get
+/// placeholder values the user then edits.
+fn struct_skeleton(specs: &'static [SubFieldSpec]) -> Value {
+    if std::ptr::eq(specs.as_ptr(), super::fields::DUCKING_RULE_FIELDS.as_ptr()) {
+        serde_json::json!({
+            "primary_voice": "",
+            "ducked_voices": [],
+            "target_volume": 0.5,
+            "fade_duration_ms": 500
+        })
+    } else if std::ptr::eq(specs.as_ptr(), super::fields::INPUT_ROUTE_FIELDS.as_ptr()) {
+        serde_json::json!({ "source_channel": 0, "dest_channel": 0 })
+    } else {
+        Value::Object(serde_json::Map::new())
+    }
+}
+
+/// One-line summary of a struct-list item from its first few fields.
+fn summarize_struct(value: &Value, specs: &'static [SubFieldSpec]) -> String {
+    let Some(obj) = value.as_object() else {
+        return "(invalid)".to_string();
+    };
+    let mut parts = Vec::new();
+    for spec in specs.iter().take(3) {
+        if let Some(v) = obj.get(spec.key) {
+            let text = match v {
+                Value::String(s) => s.clone(),
+                Value::Array(a) => format!("[{}]", a.len()),
+                other => other.to_string(),
+            };
+            parts.push(format!("{}={}", spec.key, text));
+        }
+    }
+    if parts.is_empty() {
+        "(new)".to_string()
+    } else {
+        parts.join("  ")
+    }
+}

--- a/src/config_editor/device_test.rs
+++ b/src/config_editor/device_test.rs
@@ -1,0 +1,299 @@
+// ABOUTME: Headless live device test sessions for the config editor.
+// ABOUTME: Plays test tones through the real output pathway and meters input capture.
+
+use crate::audio::bass_management::{BassManagement, BassManagementConfig};
+use crate::audio::engine::{build_output_stream, find_output_config, find_output_device};
+use crate::audio::input::{create_input_stream, ActiveInput, InputStreamConfig};
+use crate::audio::mixer::{db_to_linear, ActiveSample, MixerState};
+use crate::audio::types::DecodedBuffer;
+use crate::config::Config;
+use crate::rt_engine::{
+    command_channel, command_return_channel, graveyard_channel, streamed_graveyard_channel,
+    AudioCallbackState, AudioCommand, CommandProducer, CommandReturnConsumer, GraveyardConsumer,
+    StreamedGraveyardConsumer,
+};
+use cpal::traits::StreamTrait;
+use parking_lot::Mutex;
+use ringbuf::HeapConsumer;
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
+use std::sync::Arc;
+
+/// Generate a mono sine tone with linear fade-in/out edges so playback never
+/// clicks. Returns interleavable mono f32 samples at `sample_rate`.
+pub fn generate_tone(
+    freq_hz: f32,
+    sample_rate: u32,
+    duration_ms: u32,
+    fade_ms: u32,
+    amplitude: f32,
+) -> Vec<f32> {
+    let total = (sample_rate as u64 * duration_ms as u64 / 1000) as usize;
+    let fade = ((sample_rate as u64 * fade_ms as u64 / 1000) as usize).min(total / 2);
+    let mut samples = Vec::with_capacity(total);
+    for n in 0..total {
+        let phase = 2.0 * std::f32::consts::PI * freq_hz * n as f32 / sample_rate as f32;
+        let mut s = amplitude * phase.sin();
+        if fade > 0 {
+            if n < fade {
+                s *= n as f32 / fade as f32;
+            }
+            if n >= total - fade {
+                s *= (total - n - 1) as f32 / fade as f32;
+            }
+        }
+        samples.push(s);
+    }
+    samples
+}
+
+/// A live output test: a real stream on the chosen device, fed through the real
+/// mixer (channel gains, master gain, limiter, and bass management from the
+/// in-progress config), into which test tones are injected per channel.
+pub struct OutputTestSession {
+    stream: cpal::Stream,
+    commands: CommandProducer,
+    command_returns: CommandReturnConsumer,
+    graveyard: GraveyardConsumer,
+    _streamed_graveyard: StreamedGraveyardConsumer,
+    error_flag: Arc<AtomicBool>,
+    xruns: Arc<AtomicU64>,
+    output_meters: Arc<Vec<AtomicU32>>,
+    next_id: u64,
+    /// Negotiated output channel count.
+    pub channels: usize,
+    /// Negotiated output sample rate (Hz).
+    pub sample_rate: u32,
+    /// Human-readable negotiation summary, e.g. "6 ch @ 48000 Hz, F32".
+    pub description: String,
+}
+
+/// Frequency of the standard speaker-identification tone.
+pub const TEST_TONE_HZ: f32 = 440.0;
+/// Frequency of the bass test tone (below any sane crossover, so an enabled
+/// bass management config routes it to the LFE channel audibly).
+pub const BASS_TONE_HZ: f32 = 50.0;
+/// Length of a test tone in milliseconds.
+pub const TONE_DURATION_MS: u32 = 500;
+const TONE_FADE_MS: u32 = 8;
+const TONE_AMPLITUDE: f32 = 0.5;
+
+/// Open `device_name` (None = default) through the real pathway —
+/// `find_output_device` -> `find_output_config` -> `build_output_stream` — with
+/// a mixer configured from `config`'s audio and bass management settings, so a
+/// test tone is heard exactly as the daemon would play it.
+pub fn start_output_test(
+    config: &Config,
+    device_name: Option<&str>,
+) -> Result<OutputTestSession, String> {
+    let device = find_output_device(device_name).map_err(|e| e.to_string())?;
+    let output_config = find_output_config(
+        &device,
+        config.audio.channels,
+        Some(config.audio.sample_rate),
+        config.audio.buffer_size,
+    )
+    .map_err(|e| e.to_string())?;
+    let channels = output_config.stream_config.channels as usize;
+    let sample_rate = output_config.stream_config.sample_rate;
+    let description = format!(
+        "{} ch @ {} Hz, {:?}",
+        channels, sample_rate, output_config.sample_format
+    );
+
+    let mut mixer = MixerState::new(channels);
+    mixer.channel_gains = config.resolve_channel_gains(channels);
+    mixer.master_gain = config.audio.master_gain;
+    mixer.output_ceiling = db_to_linear(config.audio.output_ceiling_db);
+    if config.bass_management.enabled {
+        let resolved = config.resolve_bass_management()?;
+        mixer.bass_management = Some(BassManagement::new(
+            BassManagementConfig {
+                enabled: resolved.enabled,
+                lfe_channel: resolved.lfe_channel,
+                crossover_frequency_hz: resolved.crossover_frequency_hz,
+                source_channels: resolved.source_channels,
+                remove_bass_from_sources: resolved.remove_bass_from_sources,
+                lfe_gain: resolved.lfe_gain,
+            },
+            sample_rate,
+            channels,
+        ));
+    }
+    mixer.telemetry_enabled.store(true, Ordering::Relaxed);
+    let output_meters = mixer.output_meters.clone();
+
+    let (commands, cmd_rx) = command_channel(64);
+    let (cmd_return_tx, command_returns) = command_return_channel(64);
+    let (grave_tx, graveyard) = graveyard_channel(64);
+    let (streamed_grave_tx, streamed_graveyard) = streamed_graveyard_channel(16);
+    let callback_state = Arc::new(Mutex::new(AudioCallbackState {
+        mixer,
+        commands: cmd_rx,
+        command_returns: cmd_return_tx,
+        graveyard: grave_tx,
+        streamed_graveyard: streamed_grave_tx,
+        output_sample_rate: sample_rate,
+    }));
+    let xruns = Arc::new(AtomicU64::new(0));
+    let error_flag = Arc::new(AtomicBool::new(false));
+
+    // Built directly (not via the supervisor, which exits the process on an
+    // unrecoverable device failure); a mid-test device error surfaces through
+    // `error_flag` instead.
+    let stream = build_output_stream(
+        &device,
+        &output_config.stream_config,
+        output_config.sample_format,
+        callback_state,
+        xruns.clone(),
+        error_flag.clone(),
+    )
+    .map_err(|e| e.to_string())?;
+    stream.play().map_err(|e| e.to_string())?;
+
+    Ok(OutputTestSession {
+        stream,
+        commands,
+        command_returns,
+        graveyard,
+        _streamed_graveyard: streamed_graveyard,
+        error_flag,
+        xruns,
+        output_meters,
+        next_id: 1,
+        channels,
+        sample_rate,
+        description,
+    })
+}
+
+impl OutputTestSession {
+    /// Inject a tone routed to one output channel via the sample channel map,
+    /// exactly as a play command with a channel route would.
+    pub fn play_tone_on_channel(&mut self, channel: usize, freq_hz: f32) -> Result<(), String> {
+        if channel >= self.channels {
+            return Err(format!(
+                "channel {} is beyond the {} output channels",
+                channel, self.channels
+            ));
+        }
+        let samples = generate_tone(
+            freq_hz,
+            self.sample_rate,
+            TONE_DURATION_MS,
+            TONE_FADE_MS,
+            TONE_AMPLITUDE,
+        );
+        let buffer = Arc::new(DecodedBuffer::new(samples, 1, self.sample_rate));
+        let id = self.next_id;
+        self.next_id += 1;
+        let sample = ActiveSample::new_with_mapping(
+            id,
+            "config-editor-test".to_string(),
+            buffer,
+            1.0,
+            1.0,
+            vec![(0, channel)],
+            "test-tone".to_string(),
+            None,
+            false,
+            0,
+        );
+        self.commands
+            .push(AudioCommand::AddSample(sample))
+            .map_err(|_| "command ring is full".to_string())
+    }
+
+    /// Per-channel post-limiter peak levels from the most recent audio block.
+    pub fn channel_peaks(&self) -> Vec<f32> {
+        self.output_meters
+            .iter()
+            .map(|m| f32::from_bits(m.load(Ordering::Relaxed)))
+            .collect()
+    }
+
+    /// Drain the off-RT return rings (the editor's stand-in for the daemon's
+    /// reaper) and report a stream error if one occurred. Call periodically.
+    pub fn poll(&mut self) -> Result<(), String> {
+        while self.graveyard.pop().is_some() {}
+        while self.command_returns.pop().is_some() {}
+        if self.error_flag.load(Ordering::Relaxed) {
+            return Err(format!(
+                "audio stream error (xruns: {})",
+                self.xruns.load(Ordering::Relaxed)
+            ));
+        }
+        Ok(())
+    }
+}
+
+impl Drop for OutputTestSession {
+    fn drop(&mut self) {
+        // Stop the callback before the rings are torn down, then free anything
+        // still parked in the return rings off-RT (the rings drop with self).
+        let _ = self.stream.pause();
+        while self.graveyard.pop().is_some() {}
+        while self.command_returns.pop().is_some() {}
+    }
+}
+
+/// A live input test: the real capture stream with a per-channel peak meter,
+/// so the user can verify the right microphone before saving an inputs[] entry.
+pub struct InputTestSession {
+    _input: ActiveInput,
+    consumer: HeapConsumer<f32>,
+    /// Channel count of the opened input device.
+    pub channels: usize,
+    /// Current per-channel peak (decayed each poll for a live-meter feel).
+    peaks: Vec<f32>,
+}
+
+/// Open the input device through the daemon's real capture path
+/// (`create_input_stream`, including its async resampler) and meter it.
+pub fn start_input_test(
+    device_name: Option<&str>,
+    latency_ms: u32,
+    sample_rate: u32,
+) -> Result<InputTestSession, String> {
+    let mut input = create_input_stream(
+        InputStreamConfig {
+            device_name: device_name.map(|s| s.to_string()),
+            latency_ms,
+        },
+        sample_rate,
+    )
+    .map_err(|e| e.to_string())?;
+    let consumer = input
+        .take_consumer()
+        .ok_or_else(|| "input consumer already taken".to_string())?;
+    let channels = input.channels;
+    Ok(InputTestSession {
+        _input: input,
+        consumer,
+        channels,
+        peaks: vec![0.0; channels],
+    })
+}
+
+impl InputTestSession {
+    /// Drain captured audio and update the per-channel peaks. Existing peaks
+    /// decay toward zero so the meter falls back when the room goes quiet.
+    pub fn poll(&mut self) {
+        for p in &mut self.peaks {
+            *p *= 0.7;
+        }
+        let mut ch = 0usize;
+        while let Some(s) = self.consumer.pop() {
+            let a = s.abs();
+            if a > self.peaks[ch] {
+                self.peaks[ch] = a;
+            }
+            ch = (ch + 1) % self.channels;
+        }
+    }
+
+    /// Current per-channel peak levels (0.0 - 1.0-ish).
+    pub fn peaks(&self) -> &[f32] {
+        &self.peaks
+    }
+}

--- a/src/config_editor/fields.rs
+++ b/src/config_editor/fields.rs
@@ -1,0 +1,1009 @@
+// ABOUTME: Declarative field registry and sparse JSON document model for the config editor.
+// ABOUTME: Maps every config field to a JSON path, edit kind, bounds, and help text.
+
+use crate::config::Config;
+use serde_json::Value;
+
+/// One segment of a path into the config JSON document.
+#[derive(Clone, Debug, PartialEq)]
+pub enum Seg {
+    Key(String),
+    Idx(usize),
+}
+
+/// Build a path from static key segments.
+pub fn path_of(keys: &[&str]) -> Vec<Seg> {
+    keys.iter().map(|k| Seg::Key(k.to_string())).collect()
+}
+
+/// The config file being edited, kept as raw JSON so that only explicitly-set
+/// keys are written on save: untouched fields stay absent (the daemon's
+/// compiled-in defaults apply) and unknown keys/comments pass through unchanged.
+#[derive(Clone, Debug)]
+pub struct ConfigDocument {
+    root: Value,
+}
+
+impl ConfigDocument {
+    /// An empty document (a new config).
+    pub fn new() -> Self {
+        Self {
+            root: Value::Object(serde_json::Map::new()),
+        }
+    }
+
+    /// Wrap an already-parsed config file. Fails unless the root is an object.
+    pub fn from_value(root: Value) -> Result<Self, String> {
+        if root.is_object() {
+            Ok(Self { root })
+        } else {
+            Err("config root must be a JSON object".to_string())
+        }
+    }
+
+    /// Parse a config file's text.
+    pub fn parse(text: &str) -> Result<Self, String> {
+        let root: Value = serde_json::from_str(text).map_err(|e| e.to_string())?;
+        Self::from_value(root)
+    }
+
+    /// The raw document. Used by the integration tests to inspect what a save
+    /// would write; the binary's editor goes through the typed accessors, so
+    /// the binary build would otherwise flag it dead.
+    #[allow(dead_code)]
+    pub fn root(&self) -> &Value {
+        &self.root
+    }
+
+    /// The value at `path`, if explicitly set.
+    pub fn get(&self, path: &[Seg]) -> Option<&Value> {
+        let mut cur = &self.root;
+        for seg in path {
+            cur = match seg {
+                Seg::Key(k) => cur.as_object()?.get(k)?,
+                Seg::Idx(i) => cur.as_array()?.get(*i)?,
+            };
+        }
+        Some(cur)
+    }
+
+    /// Set the value at `path`, creating intermediate objects as needed.
+    /// Intermediate array indices must already exist (lists grow via `push`).
+    pub fn set(&mut self, path: &[Seg], value: Value) {
+        let Some((last, parents)) = path.split_last() else {
+            return;
+        };
+        let mut cur = &mut self.root;
+        for seg in parents {
+            match seg {
+                Seg::Key(k) => {
+                    if !cur.is_object() {
+                        *cur = Value::Object(serde_json::Map::new());
+                    }
+                    cur = cur
+                        .as_object_mut()
+                        .expect("just ensured object")
+                        .entry(k.clone())
+                        .or_insert_with(|| Value::Object(serde_json::Map::new()));
+                }
+                Seg::Idx(i) => {
+                    let Some(arr) = cur.as_array_mut() else {
+                        return;
+                    };
+                    let Some(next) = arr.get_mut(*i) else {
+                        return;
+                    };
+                    cur = next;
+                }
+            }
+        }
+        match last {
+            Seg::Key(k) => {
+                if !cur.is_object() {
+                    *cur = Value::Object(serde_json::Map::new());
+                }
+                cur.as_object_mut()
+                    .expect("just ensured object")
+                    .insert(k.clone(), value);
+            }
+            Seg::Idx(i) => {
+                if let Some(arr) = cur.as_array_mut() {
+                    if let Some(slot) = arr.get_mut(*i) {
+                        *slot = value;
+                    }
+                }
+            }
+        }
+    }
+
+    /// Append `value` to the array at `path`, creating the array if absent.
+    pub fn push(&mut self, path: &[Seg], value: Value) {
+        match self.get(path) {
+            Some(Value::Array(_)) => {}
+            _ => self.set(path, Value::Array(Vec::new())),
+        }
+        if let Some(Value::Array(arr)) = self.get_mut(path) {
+            arr.push(value);
+        }
+    }
+
+    fn get_mut(&mut self, path: &[Seg]) -> Option<&mut Value> {
+        let mut cur = &mut self.root;
+        for seg in path {
+            cur = match seg {
+                Seg::Key(k) => cur.as_object_mut()?.get_mut(k)?,
+                Seg::Idx(i) => cur.as_array_mut()?.get_mut(*i)?,
+            };
+        }
+        Some(cur)
+    }
+
+    /// Remove the key (or array element) at `path`, pruning any parent objects
+    /// left empty (an empty section object deserializes the same as an absent
+    /// one, so pruning keeps saved files sparse without changing meaning).
+    pub fn unset(&mut self, path: &[Seg]) {
+        let Some((last, parents)) = path.split_last() else {
+            return;
+        };
+        if let Some(parent) = self.get_mut(parents) {
+            match last {
+                Seg::Key(k) => {
+                    if let Some(obj) = parent.as_object_mut() {
+                        obj.remove(k);
+                    }
+                }
+                Seg::Idx(i) => {
+                    if let Some(arr) = parent.as_array_mut() {
+                        if *i < arr.len() {
+                            arr.remove(*i);
+                        }
+                    }
+                }
+            }
+        }
+        // Prune empty parent objects (never the root, never arrays: an empty
+        // array may be meaningful, e.g. clearing a list).
+        for depth in (1..path.len()).rev() {
+            let parent_path = &path[..depth];
+            let is_empty_obj =
+                matches!(self.get(parent_path), Some(Value::Object(o)) if o.is_empty());
+            if is_empty_obj {
+                let Some((last, parents)) = parent_path.split_last() else {
+                    break;
+                };
+                if let (Some(Value::Object(obj)), Seg::Key(k)) = (self.get_mut(parents), last) {
+                    obj.remove(k);
+                }
+            } else {
+                break;
+            }
+        }
+    }
+
+    /// Number of elements in the array at `path` (0 when absent).
+    pub fn list_len(&self, path: &[Seg]) -> usize {
+        match self.get(path) {
+            Some(Value::Array(arr)) => arr.len(),
+            _ => 0,
+        }
+    }
+
+    /// Deserialize this document into a `Config` exactly as the daemon would,
+    /// so compiled-in defaults fill every unset field identically.
+    pub fn to_config(&self) -> Result<Config, String> {
+        serde_json::from_value(self.root.clone()).map_err(|e| e.to_string())
+    }
+
+    /// Pretty-printed JSON with a trailing newline, ready to write to disk.
+    pub fn to_pretty_string(&self) -> String {
+        let mut s = serde_json::to_string_pretty(&self.root).unwrap_or_else(|_| "{}".to_string());
+        s.push('\n');
+        s
+    }
+}
+
+impl Default for ConfigDocument {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// How a field is edited and displayed.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum FieldKind {
+    /// A required string (always has a default).
+    Text,
+    /// An optional string; unset means the daemon default (often "none").
+    OptionalText,
+    /// An optional string rendered masked.
+    Secret,
+    /// A boolean toggle.
+    Bool,
+    /// Presence of an object acts as an on/off switch ({} = on, absent = off).
+    Flag,
+    /// An unsigned integer within [min, max].
+    UInt { min: u64, max: u64 },
+    /// An optional unsigned integer within [min, max]; unset = automatic.
+    OptionalUInt { min: u64, max: u64 },
+    /// A float within [min, max].
+    Float { min: f64, max: f64 },
+    /// One of a fixed set of lowercase string options.
+    Enum(&'static [&'static str]),
+    /// The audio output device name; edited via the device picker.
+    OutputDevice,
+    /// An audio input device name; edited via the input device picker.
+    InputDevice,
+    /// A list of strings.
+    StringList,
+    /// A map of string keys to unsigned integers (channel aliases).
+    MapToUInt,
+    /// A map of string keys to floats within [min, max] (channel volumes).
+    MapToFloat { min: f64, max: f64 },
+    /// A map of string keys to arbitrary JSON values (macros).
+    MapToJson,
+    /// A channel reference: numeric index or alias string.
+    ChannelRef,
+    /// A list of channel references.
+    ChannelRefList,
+    /// The cache memory budget (tagged mode: auto/explicit/unlimited).
+    MemoryBudget,
+    /// A list of structs edited via nested sub-forms.
+    StructList(&'static [SubFieldSpec]),
+}
+
+/// A field of a struct inside a list (ducking rules, inputs, routes).
+#[derive(Debug, PartialEq)]
+pub struct SubFieldSpec {
+    pub key: &'static str,
+    pub label: &'static str,
+    pub kind: FieldKind,
+    pub help: &'static str,
+}
+
+/// The editor's sections, in sidebar order.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Section {
+    Mqtt,
+    Audio,
+    Cache,
+    Security,
+    Logging,
+    Http,
+    Ducking,
+    BassManagement,
+    Inputs,
+    Advanced,
+    Macros,
+}
+
+impl Section {
+    pub const ALL: [Section; 11] = [
+        Section::Mqtt,
+        Section::Audio,
+        Section::Cache,
+        Section::Security,
+        Section::Logging,
+        Section::Http,
+        Section::Ducking,
+        Section::BassManagement,
+        Section::Inputs,
+        Section::Advanced,
+        Section::Macros,
+    ];
+
+    pub fn title(&self) -> &'static str {
+        match self {
+            Section::Mqtt => "MQTT",
+            Section::Audio => "Audio",
+            Section::Cache => "Cache",
+            Section::Security => "Security",
+            Section::Logging => "Logging",
+            Section::Http => "HTTP",
+            Section::Ducking => "Ducking Rules",
+            Section::BassManagement => "Bass Management",
+            Section::Inputs => "Inputs",
+            Section::Advanced => "Advanced",
+            Section::Macros => "Macros",
+        }
+    }
+}
+
+/// A top-level config field: where it lives in the JSON document, how it is
+/// edited, and what to tell the user about it.
+pub struct FieldSpec {
+    pub section: Section,
+    pub label: &'static str,
+    pub path: &'static [&'static str],
+    pub kind: FieldKind,
+    pub help: &'static str,
+}
+
+/// Fields of one ducking rule.
+pub static DUCKING_RULE_FIELDS: [SubFieldSpec; 4] = [
+    SubFieldSpec {
+        key: "primary_voice",
+        label: "primary_voice",
+        kind: FieldKind::Text,
+        help: "Voice that triggers ducking when it has active samples.",
+    },
+    SubFieldSpec {
+        key: "ducked_voices",
+        label: "ducked_voices",
+        kind: FieldKind::StringList,
+        help: "Voices to reduce in volume while the primary voice is active.",
+    },
+    SubFieldSpec {
+        key: "target_volume",
+        label: "target_volume",
+        kind: FieldKind::Float { min: 0.0, max: 1.0 },
+        help: "Volume the ducked voices fade to (0.0 - 1.0).",
+    },
+    SubFieldSpec {
+        key: "fade_duration_ms",
+        label: "fade_duration_ms",
+        kind: FieldKind::UInt {
+            min: 0,
+            max: u32::MAX as u64,
+        },
+        help: "Fade duration in milliseconds for ducking transitions.",
+    },
+];
+
+/// Fields of one input route (input channel -> output channel).
+pub static INPUT_ROUTE_FIELDS: [SubFieldSpec; 2] = [
+    SubFieldSpec {
+        key: "source_channel",
+        label: "source_channel",
+        kind: FieldKind::ChannelRef,
+        help: "Source channel on the input device (0-indexed number or alias).",
+    },
+    SubFieldSpec {
+        key: "dest_channel",
+        label: "dest_channel",
+        kind: FieldKind::ChannelRef,
+        help: "Destination channel on the output device (0-indexed number or alias).",
+    },
+];
+
+/// Fields of one microphone input.
+pub static INPUT_FIELDS: [SubFieldSpec; 5] = [
+    SubFieldSpec {
+        key: "device",
+        label: "device",
+        kind: FieldKind::InputDevice,
+        help: "Input device name. Unset uses the default input device.",
+    },
+    SubFieldSpec {
+        key: "volume",
+        label: "volume",
+        kind: FieldKind::Float { min: 0.0, max: 1.0 },
+        help: "Input volume (0.0 - 1.0). Default 1.0.",
+    },
+    SubFieldSpec {
+        key: "voice_id",
+        label: "voice_id",
+        kind: FieldKind::Text,
+        help: "Voice name for ducking integration and status. Default \"mic\".",
+    },
+    SubFieldSpec {
+        key: "routes",
+        label: "routes",
+        kind: FieldKind::StructList(&INPUT_ROUTE_FIELDS),
+        help: "Channel routing from input to output. Must not be empty.",
+    },
+    SubFieldSpec {
+        key: "latency_ms",
+        label: "latency_ms",
+        kind: FieldKind::UInt { min: 5, max: 500 },
+        help: "Buffer latency in milliseconds (5 - 500). Default 20.",
+    },
+];
+
+/// Every config field the editor can set, in display order. The coverage test
+/// in tests/config_editor_test.rs asserts this stays complete as the config
+/// schema grows.
+pub static REGISTRY: [FieldSpec; 54] = [
+    // --- MQTT ---
+    FieldSpec {
+        section: Section::Mqtt,
+        label: "server",
+        path: &["mqtt", "server"],
+        kind: FieldKind::Text,
+        help: "MQTT broker hostname or IP address.",
+    },
+    FieldSpec {
+        section: Section::Mqtt,
+        label: "port",
+        path: &["mqtt", "port"],
+        kind: FieldKind::UInt { min: 1, max: 65535 },
+        help: "MQTT broker TCP port (plain default 1883, TLS commonly 8883).",
+    },
+    FieldSpec {
+        section: Section::Mqtt,
+        label: "topic",
+        path: &["mqtt", "topic"],
+        kind: FieldKind::OptionalText,
+        help: "Topic to subscribe to for commands (wildcards # and + work). Required unless the HTTP server is enabled.",
+    },
+    FieldSpec {
+        section: Section::Mqtt,
+        label: "client_id",
+        path: &["mqtt", "client_id"],
+        kind: FieldKind::OptionalText,
+        help: "MQTT client id. Unset auto-generates mqttaudio_<pid>.",
+    },
+    FieldSpec {
+        section: Section::Mqtt,
+        label: "reconnect_delay_seconds",
+        path: &["mqtt", "reconnect_delay_seconds"],
+        kind: FieldKind::UInt {
+            min: 1,
+            max: 86400,
+        },
+        help: "Seconds to wait before reconnecting after losing the broker.",
+    },
+    FieldSpec {
+        section: Section::Mqtt,
+        label: "username",
+        path: &["mqtt", "username"],
+        kind: FieldKind::OptionalText,
+        help: "Broker username for authentication. Unset = anonymous.",
+    },
+    FieldSpec {
+        section: Section::Mqtt,
+        label: "password",
+        path: &["mqtt", "password"],
+        kind: FieldKind::Secret,
+        help: "Broker password. Sent in cleartext unless TLS is enabled.",
+    },
+    FieldSpec {
+        section: Section::Mqtt,
+        label: "tls",
+        path: &["mqtt", "tls"],
+        kind: FieldKind::Flag,
+        help: "Enable TLS to the broker. Off = plain TCP (even on port 8883).",
+    },
+    FieldSpec {
+        section: Section::Mqtt,
+        label: "tls.ca_path",
+        path: &["mqtt", "tls", "ca_path"],
+        kind: FieldKind::OptionalText,
+        help: "PEM CA certificate to trust (self-signed/private brokers). Unset uses the system root store. Setting this enables TLS.",
+    },
+    // --- Audio ---
+    FieldSpec {
+        section: Section::Audio,
+        label: "device",
+        path: &["audio", "device"],
+        kind: FieldKind::OutputDevice,
+        help: "Audio output device. Unset uses the system default. Enter opens the device picker with live testing.",
+    },
+    FieldSpec {
+        section: Section::Audio,
+        label: "sample_rate",
+        path: &["audio", "sample_rate"],
+        kind: FieldKind::UInt {
+            min: 8000,
+            max: 192000,
+        },
+        help: "Output sample rate in Hz (8000 - 192000). Default 48000.",
+    },
+    FieldSpec {
+        section: Section::Audio,
+        label: "channels",
+        path: &["audio", "channels"],
+        kind: FieldKind::OptionalUInt { min: 1, max: 65535 },
+        help: "Number of output channels. Unset auto-detects from the device.",
+    },
+    FieldSpec {
+        section: Section::Audio,
+        label: "buffer_size",
+        path: &["audio", "buffer_size"],
+        kind: FieldKind::UInt { min: 64, max: 8192 },
+        help: "Buffer size in frames (64 - 8192). Smaller = lower latency, higher CPU. Default 512.",
+    },
+    FieldSpec {
+        section: Section::Audio,
+        label: "channel_aliases",
+        path: &["audio", "channel_aliases"],
+        kind: FieldKind::MapToUInt,
+        help: "Friendly names for channel numbers (e.g. front_left = 0), usable wherever a channel is referenced.",
+    },
+    FieldSpec {
+        section: Section::Audio,
+        label: "channel_volumes",
+        path: &["audio", "channel_volumes"],
+        kind: FieldKind::MapToFloat { min: 0.0, max: 1.0 },
+        help: "Per-channel calibration gain (key: channel number or alias, value 0.0 - 1.0). Unlisted channels stay at 1.0.",
+    },
+    FieldSpec {
+        section: Section::Audio,
+        label: "output_ceiling_db",
+        path: &["audio", "output_ceiling_db"],
+        kind: FieldKind::Float {
+            min: -60.0,
+            max: 0.0,
+        },
+        help: "Limiter ceiling in dBFS; the output peak is held at or below it. Default -1.0.",
+    },
+    FieldSpec {
+        section: Section::Audio,
+        label: "master_gain",
+        path: &["audio", "master_gain"],
+        kind: FieldKind::Float { min: 0.0, max: 8.0 },
+        help: "Linear gain applied to the summed bus before limiting. Default 1.0 (unity).",
+    },
+    // --- Cache ---
+    FieldSpec {
+        section: Section::Cache,
+        label: "enabled",
+        path: &["cache", "enabled"],
+        kind: FieldKind::Bool,
+        help: "Cache decoded audio on disk for fast replays. Default on.",
+    },
+    FieldSpec {
+        section: Section::Cache,
+        label: "directory",
+        path: &["cache", "directory"],
+        kind: FieldKind::Text,
+        help: "Cache directory (~ expands to home). Default ~/.mqttaudio/cache.",
+    },
+    FieldSpec {
+        section: Section::Cache,
+        label: "revalidate_after_seconds",
+        path: &["cache", "revalidate_after_seconds"],
+        kind: FieldKind::UInt {
+            min: 0,
+            max: u32::MAX as u64,
+        },
+        help: "Revalidation window for remote (HTTP) cache entries in seconds. 0 = always re-check. Default 300.",
+    },
+    FieldSpec {
+        section: Section::Cache,
+        label: "precache",
+        path: &["cache", "precache"],
+        kind: FieldKind::StringList,
+        help: "Files, directories (non-recursive), or HTTP URLs to cache at startup.",
+    },
+    FieldSpec {
+        section: Section::Cache,
+        label: "precache_blocking",
+        path: &["cache", "precache_blocking"],
+        kind: FieldKind::Bool,
+        help: "Block startup until precache finishes (on, default) or load in the background (off).",
+    },
+    FieldSpec {
+        section: Section::Cache,
+        label: "max_memory_mb",
+        path: &["cache", "max_memory_mb"],
+        kind: FieldKind::UInt {
+            min: 0,
+            max: u32::MAX as u64,
+        },
+        help: "Memory cache cap in MiB. 0 (default) auto-detects a bounded cap. Overridden by memory_budget.",
+    },
+    FieldSpec {
+        section: Section::Cache,
+        label: "memory_budget",
+        path: &["cache", "memory_budget"],
+        kind: FieldKind::MemoryBudget,
+        help: "Advanced memory cap: auto (fraction of RAM, clamped), explicit (fixed MiB), or unlimited. Overrides max_memory_mb.",
+    },
+    FieldSpec {
+        section: Section::Cache,
+        label: "load_mode",
+        path: &["cache", "load_mode"],
+        kind: FieldKind::Enum(&["auto", "full", "stream"]),
+        help: "Default load strategy: auto (size/duration decides), full (in-memory, all features), stream (bounded memory, forward-only).",
+    },
+    FieldSpec {
+        section: Section::Cache,
+        label: "full_load_max_bytes",
+        path: &["cache", "full_load_max_bytes"],
+        kind: FieldKind::UInt {
+            min: 0,
+            max: u64::MAX,
+        },
+        help: "Auto threshold: assets with a larger estimated decoded size are streamed. Default 33554432 (32 MiB).",
+    },
+    FieldSpec {
+        section: Section::Cache,
+        label: "full_load_max_seconds",
+        path: &["cache", "full_load_max_seconds"],
+        kind: FieldKind::UInt {
+            min: 0,
+            max: u32::MAX as u64,
+        },
+        help: "Auto threshold: assets longer than this many seconds are streamed. Default 60.",
+    },
+    FieldSpec {
+        section: Section::Cache,
+        label: "stream_window_ms",
+        path: &["cache", "stream_window_ms"],
+        kind: FieldKind::UInt {
+            min: 100,
+            max: 60000,
+        },
+        help: "Streamed-source ring depth in ms; bounds per-stream memory (100 - 60000). Default 1500.",
+    },
+    FieldSpec {
+        section: Section::Cache,
+        label: "stream_prebuffer_ms",
+        path: &["cache", "stream_prebuffer_ms"],
+        kind: FieldKind::UInt { min: 0, max: 60000 },
+        help: "Audio prebuffered before a streamed source starts (ms). Must not exceed stream_window_ms. Default 150.",
+    },
+    FieldSpec {
+        section: Section::Cache,
+        label: "stream_prebuffer_deadline_ms",
+        path: &["cache", "stream_prebuffer_deadline_ms"],
+        kind: FieldKind::UInt {
+            min: 0,
+            max: 600000,
+        },
+        help: "Max wait for the prebuffer before starting anyway (ms). Must be >= stream_prebuffer_ms. Default 300.",
+    },
+    FieldSpec {
+        section: Section::Cache,
+        label: "freshness",
+        path: &["cache", "freshness"],
+        kind: FieldKind::Enum(&["trusting", "dev", "pinned"]),
+        help: "Cache freshness: trusting (serve cache, refresh in background), dev (re-check every load), pinned (never auto-check).",
+    },
+    // --- Security ---
+    FieldSpec {
+        section: Section::Security,
+        label: "allowed_directories",
+        path: &["security", "allowed_directories"],
+        kind: FieldKind::StringList,
+        help: "Whitelist of directories for local file playback (~ expands). Empty = any path allowed.",
+    },
+    // --- Logging ---
+    FieldSpec {
+        section: Section::Logging,
+        label: "level",
+        path: &["logging", "level"],
+        kind: FieldKind::Enum(&["error", "warn", "info", "debug", "trace"]),
+        help: "Log level. Default info.",
+    },
+    FieldSpec {
+        section: Section::Logging,
+        label: "verbose",
+        path: &["logging", "verbose"],
+        kind: FieldKind::Bool,
+        help: "Verbose mode; equivalent to level = debug.",
+    },
+    FieldSpec {
+        section: Section::Logging,
+        label: "format",
+        path: &["logging", "format"],
+        kind: FieldKind::Enum(&["text", "json"]),
+        help: "Console log format: text (human-readable) or json (line-delimited, for log aggregation).",
+    },
+    FieldSpec {
+        section: Section::Logging,
+        label: "mqtt_topic",
+        path: &["logging", "mqtt_topic"],
+        kind: FieldKind::OptionalText,
+        help: "MQTT topic to publish log records to as JSON. Unset = off.",
+    },
+    // --- HTTP ---
+    FieldSpec {
+        section: Section::Http,
+        label: "enabled",
+        path: &["http", "enabled"],
+        kind: FieldKind::Bool,
+        help: "Enable the HTTP REST/WebSocket server. Default off.",
+    },
+    FieldSpec {
+        section: Section::Http,
+        label: "port",
+        path: &["http", "port"],
+        kind: FieldKind::UInt { min: 0, max: 65535 },
+        help: "Port to listen on. 0 = auto-select an available port.",
+    },
+    FieldSpec {
+        section: Section::Http,
+        label: "bind_address",
+        path: &["http", "bind_address"],
+        kind: FieldKind::Text,
+        help: "Bind address. Default 127.0.0.1 (loopback only) for security.",
+    },
+    FieldSpec {
+        section: Section::Http,
+        label: "auth_token",
+        path: &["http", "auth_token"],
+        kind: FieldKind::Secret,
+        help: "Bearer token protecting command routes (min 8 characters). Unset = open.",
+    },
+    FieldSpec {
+        section: Section::Http,
+        label: "websocket_enabled",
+        path: &["http", "websocket_enabled"],
+        kind: FieldKind::Bool,
+        help: "Enable the /ws WebSocket endpoint for live log streaming. Default on.",
+    },
+    FieldSpec {
+        section: Section::Http,
+        label: "cors_permissive",
+        path: &["http", "cors_permissive"],
+        kind: FieldKind::Bool,
+        help: "Allow CORS from any origin (for web admin panels). Default off.",
+    },
+    FieldSpec {
+        section: Section::Http,
+        label: "require_auth",
+        path: &["http", "require_auth"],
+        kind: FieldKind::Bool,
+        help: "Require the token on ALL routes including status/health/ws. Default off.",
+    },
+    // --- Ducking ---
+    FieldSpec {
+        section: Section::Ducking,
+        label: "ducking_rules",
+        path: &["ducking_rules"],
+        kind: FieldKind::StructList(&DUCKING_RULE_FIELDS),
+        help: "Automatic volume reduction: while a primary voice plays, listed voices duck to a target volume.",
+    },
+    // --- Bass management ---
+    FieldSpec {
+        section: Section::BassManagement,
+        label: "enabled",
+        path: &["bass_management", "enabled"],
+        kind: FieldKind::Bool,
+        help: "Extract bass from source channels into a subwoofer (LFE) channel. Default off.",
+    },
+    FieldSpec {
+        section: Section::BassManagement,
+        label: "lfe_channel",
+        path: &["bass_management", "lfe_channel"],
+        kind: FieldKind::ChannelRef,
+        help: "Output channel for the subwoofer (number or alias). Default 3 (standard 5.1 LFE position).",
+    },
+    FieldSpec {
+        section: Section::BassManagement,
+        label: "crossover_frequency_hz",
+        path: &["bass_management", "crossover_frequency_hz"],
+        kind: FieldKind::Float {
+            min: 10.0,
+            max: 200.0,
+        },
+        help: "Crossover frequency in Hz (10 - 200). Default 80.",
+    },
+    FieldSpec {
+        section: Section::BassManagement,
+        label: "source_channels",
+        path: &["bass_management", "source_channels"],
+        kind: FieldKind::ChannelRefList,
+        help: "Channels to extract bass from (numbers or aliases). Must not include the LFE channel.",
+    },
+    FieldSpec {
+        section: Section::BassManagement,
+        label: "remove_bass_from_sources",
+        path: &["bass_management", "remove_bass_from_sources"],
+        kind: FieldKind::Bool,
+        help: "High-pass the source channels after extraction (on, default) or leave them full-range (additive LFE).",
+    },
+    FieldSpec {
+        section: Section::BassManagement,
+        label: "lfe_gain",
+        path: &["bass_management", "lfe_gain"],
+        kind: FieldKind::Float { min: 0.0, max: 8.0 },
+        help: "Linear trim applied to the summed LFE output. Default 1.0.",
+    },
+    // --- Inputs ---
+    FieldSpec {
+        section: Section::Inputs,
+        label: "inputs",
+        path: &["inputs"],
+        kind: FieldKind::StructList(&INPUT_FIELDS),
+        help: "Live microphone inputs mixed into the output with channel routing.",
+    },
+    // --- Advanced ---
+    FieldSpec {
+        section: Section::Advanced,
+        label: "resampler_quality",
+        path: &["advanced", "resampler_quality"],
+        kind: FieldKind::Enum(&["fast", "medium", "high", "maximum"]),
+        help: "Sample-rate conversion quality. fast (default, ~60ms/min stereo) to maximum (~230ms/min; precache-everything setups only).",
+    },
+    FieldSpec {
+        section: Section::Advanced,
+        label: "schema_version",
+        path: &["schema_version"],
+        kind: FieldKind::OptionalUInt {
+            min: 0,
+            max: u32::MAX as u64,
+        },
+        help: "Config schema version marker. Unset = current. Rarely needs setting by hand.",
+    },
+    // --- Macros ---
+    FieldSpec {
+        section: Section::Macros,
+        label: "macros",
+        path: &["macros"],
+        kind: FieldKind::MapToJson,
+        help: "Command parameter presets: each macro name maps to a JSON object merged into commands that reference it.",
+    },
+];
+
+/// The registry entries belonging to `section`, in declaration order.
+pub fn section_fields(section: Section) -> Vec<&'static FieldSpec> {
+    REGISTRY.iter().filter(|f| f.section == section).collect()
+}
+
+/// `Config::default()` serialized to JSON, used to display compiled-in defaults
+/// for unset fields.
+pub fn default_config_value() -> Value {
+    serde_json::to_value(Config::default()).unwrap_or(Value::Null)
+}
+
+/// Parse user-typed text into a JSON value for a scalar field kind. Returns a
+/// human-readable error when the text does not fit the kind or its bounds.
+/// Empty input on optional kinds means "unset" and returns Ok(None).
+pub fn parse_field_value(kind: &FieldKind, input: &str) -> Result<Option<Value>, String> {
+    let trimmed = input.trim();
+    match kind {
+        FieldKind::Text => {
+            if trimmed.is_empty() {
+                Err("a value is required".to_string())
+            } else {
+                Ok(Some(Value::String(trimmed.to_string())))
+            }
+        }
+        FieldKind::OptionalText
+        | FieldKind::Secret
+        | FieldKind::OutputDevice
+        | FieldKind::InputDevice => {
+            if trimmed.is_empty() {
+                Ok(None)
+            } else {
+                Ok(Some(Value::String(trimmed.to_string())))
+            }
+        }
+        FieldKind::UInt { min, max } => {
+            let n: u64 = trimmed
+                .parse()
+                .map_err(|_| format!("'{}' is not a whole number", trimmed))?;
+            if n < *min || n > *max {
+                return Err(format!("must be between {} and {}", min, max));
+            }
+            Ok(Some(Value::Number(n.into())))
+        }
+        FieldKind::OptionalUInt { min, max } => {
+            if trimmed.is_empty() {
+                return Ok(None);
+            }
+            let n: u64 = trimmed
+                .parse()
+                .map_err(|_| format!("'{}' is not a whole number", trimmed))?;
+            if n < *min || n > *max {
+                return Err(format!("must be between {} and {}", min, max));
+            }
+            Ok(Some(Value::Number(n.into())))
+        }
+        FieldKind::Float { min, max } => {
+            let f: f64 = trimmed
+                .parse()
+                .map_err(|_| format!("'{}' is not a number", trimmed))?;
+            if !f.is_finite() {
+                return Err("must be a finite number".to_string());
+            }
+            if f < *min || f > *max {
+                return Err(format!("must be between {} and {}", min, max));
+            }
+            Ok(Some(
+                serde_json::Number::from_f64(f)
+                    .map(Value::Number)
+                    .ok_or_else(|| "not a representable number".to_string())?,
+            ))
+        }
+        FieldKind::Enum(options) => {
+            let lower = trimmed.to_lowercase();
+            if options.contains(&lower.as_str()) {
+                Ok(Some(Value::String(lower)))
+            } else {
+                Err(format!("must be one of: {}", options.join(", ")))
+            }
+        }
+        FieldKind::ChannelRef => {
+            if trimmed.is_empty() {
+                return Err("a channel number or alias is required".to_string());
+            }
+            match trimmed.parse::<u64>() {
+                Ok(idx) => Ok(Some(Value::Number(idx.into()))),
+                Err(_) => Ok(Some(Value::String(trimmed.to_string()))),
+            }
+        }
+        FieldKind::MapToJson => {
+            let v: Value =
+                serde_json::from_str(trimmed).map_err(|e| format!("invalid JSON: {}", e))?;
+            Ok(Some(v))
+        }
+        FieldKind::Bool
+        | FieldKind::Flag
+        | FieldKind::StringList
+        | FieldKind::MapToUInt
+        | FieldKind::MapToFloat { .. }
+        | FieldKind::ChannelRefList
+        | FieldKind::MemoryBudget
+        | FieldKind::StructList(_) => Err("not a text-editable field".to_string()),
+    }
+}
+
+/// Render a field's value for display. `value` is the explicitly-set value if
+/// any; the caller dims and annotates defaults itself.
+pub fn display_value(kind: &FieldKind, value: &Value) -> String {
+    match kind {
+        FieldKind::Secret => {
+            if value.is_null() {
+                "(unset)".to_string()
+            } else {
+                "********".to_string()
+            }
+        }
+        FieldKind::Flag => {
+            if value.is_null() {
+                "off".to_string()
+            } else {
+                "on".to_string()
+            }
+        }
+        FieldKind::StringList | FieldKind::ChannelRefList => match value {
+            Value::Array(arr) => format!(
+                "[{} item{}]",
+                arr.len(),
+                if arr.len() == 1 { "" } else { "s" }
+            ),
+            _ => "[0 items]".to_string(),
+        },
+        FieldKind::MapToUInt | FieldKind::MapToFloat { .. } | FieldKind::MapToJson => match value {
+            Value::Object(map) => format!(
+                "{{{} entr{}}}",
+                map.len(),
+                if map.len() == 1 { "y" } else { "ies" }
+            ),
+            _ => "{0 entries}".to_string(),
+        },
+        FieldKind::StructList(_) => match value {
+            Value::Array(arr) => format!(
+                "[{} item{}]",
+                arr.len(),
+                if arr.len() == 1 { "" } else { "s" }
+            ),
+            _ => "[0 items]".to_string(),
+        },
+        FieldKind::MemoryBudget => match value {
+            Value::Object(map) => match map.get("mode").and_then(|m| m.as_str()) {
+                Some("auto") => {
+                    let frac = map.get("fraction").and_then(|v| v.as_f64()).unwrap_or(0.4);
+                    let floor = map.get("floor_mb").and_then(|v| v.as_u64()).unwrap_or(128);
+                    let ceiling = map
+                        .get("ceiling_mb")
+                        .and_then(|v| v.as_u64())
+                        .unwrap_or(1024);
+                    format!(
+                        "auto ({:.0}% of RAM, {} - {} MiB)",
+                        frac * 100.0,
+                        floor,
+                        ceiling
+                    )
+                }
+                Some("explicit") => {
+                    let mb = map.get("mb").and_then(|v| v.as_u64()).unwrap_or(0);
+                    format!("explicit ({} MiB)", mb)
+                }
+                Some("unlimited") => "unlimited".to_string(),
+                _ => "(invalid)".to_string(),
+            },
+            _ => "(not set)".to_string(),
+        },
+        _ => match value {
+            Value::Null => "(unset)".to_string(),
+            Value::String(s) => s.clone(),
+            Value::Bool(b) => b.to_string(),
+            Value::Number(n) => n.to_string(),
+            other => other.to_string(),
+        },
+    }
+}

--- a/src/config_editor/form.rs
+++ b/src/config_editor/form.rs
@@ -1,0 +1,410 @@
+// ABOUTME: Ratatui rendering for the config editor: sidebar, forms, and modals.
+// ABOUTME: Pure drawing from App state; no state mutation happens here.
+
+use super::app::{App, Modal, Pane};
+use super::fields::Section;
+use ratatui::layout::{Constraint, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Clear, List, ListItem, ListState, Paragraph, Wrap};
+use ratatui::Frame;
+
+/// Draw one frame of the editor.
+pub fn draw(frame: &mut Frame, app: &App) {
+    let [main, help, status, keys] = Layout::vertical([
+        Constraint::Min(5),
+        Constraint::Length(2),
+        Constraint::Length(1),
+        Constraint::Length(1),
+    ])
+    .areas(frame.area());
+
+    let [sidebar, content] =
+        Layout::horizontal([Constraint::Length(20), Constraint::Min(20)]).areas(main);
+
+    draw_sidebar(frame, app, sidebar);
+    draw_content(frame, app, content);
+    draw_help(frame, app, help);
+    draw_status(frame, app, status);
+    draw_keybar(frame, app, keys);
+
+    if let Some(modal) = &app.modal {
+        draw_modal(frame, app, modal);
+    }
+}
+
+fn draw_sidebar(frame: &mut Frame, app: &App, area: Rect) {
+    let items: Vec<ListItem> = Section::ALL
+        .iter()
+        .map(|s| ListItem::new(s.title()))
+        .collect();
+    let highlight = if app.pane == Pane::Sidebar {
+        Style::default()
+            .bg(Color::Blue)
+            .fg(Color::White)
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().add_modifier(Modifier::BOLD)
+    };
+    let list = List::new(items)
+        .block(Block::default().borders(Borders::ALL).title("mqttaudio"))
+        .highlight_style(highlight);
+    let mut state = ListState::default().with_selected(Some(app.section_idx));
+    frame.render_stateful_widget(list, area, &mut state);
+}
+
+fn draw_content(frame: &mut Frame, app: &App, area: Rect) {
+    let rows = app.rows();
+    let label_width = rows.iter().map(|r| r.label.len()).max().unwrap_or(0).max(8);
+    let items: Vec<ListItem> = if rows.is_empty() {
+        vec![ListItem::new(Span::styled(
+            "(empty — press 'a' to add)",
+            Style::default().fg(Color::DarkGray),
+        ))]
+    } else {
+        rows.iter()
+            .map(|row| {
+                let value_style = if row.is_set {
+                    Style::default().fg(Color::Yellow)
+                } else {
+                    Style::default().fg(Color::DarkGray)
+                };
+                let mut spans = vec![
+                    Span::raw(format!("{:width$}  ", row.label, width = label_width)),
+                    Span::styled(row.display.clone(), value_style),
+                ];
+                if !row.is_set {
+                    spans.push(Span::styled(
+                        "  (default)",
+                        Style::default()
+                            .fg(Color::DarkGray)
+                            .add_modifier(Modifier::ITALIC),
+                    ));
+                }
+                ListItem::new(Line::from(spans))
+            })
+            .collect()
+    };
+    let highlight = if app.pane == Pane::Form {
+        Style::default().bg(Color::Blue).fg(Color::White)
+    } else {
+        Style::default()
+    };
+    let cursor = app
+        .levels
+        .last()
+        .map(|l| l.cursor)
+        .unwrap_or(0)
+        .min(items.len().saturating_sub(1));
+    let list = List::new(items)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(app.breadcrumb()),
+        )
+        .highlight_style(highlight);
+    let mut state = ListState::default().with_selected(Some(cursor));
+    frame.render_stateful_widget(list, area, &mut state);
+}
+
+fn draw_help(frame: &mut Frame, app: &App, area: Rect) {
+    if let Some(edit) = &app.edit {
+        let mut spans = vec![Span::styled(
+            format!("{}: ", edit.label),
+            Style::default().add_modifier(Modifier::BOLD),
+        )];
+        spans.extend(buffer_with_cursor(&edit.buffer, edit.cursor));
+        let mut lines = vec![Line::from(spans)];
+        if let Some(err) = &edit.error {
+            lines.push(Line::from(Span::styled(
+                err.clone(),
+                Style::default().fg(Color::Red),
+            )));
+        } else {
+            lines.push(Line::from(Span::styled(
+                "Enter: apply   Esc: cancel   (empty input unsets optional fields)",
+                Style::default().fg(Color::DarkGray),
+            )));
+        }
+        frame.render_widget(Paragraph::new(lines), area);
+        return;
+    }
+    let help = app
+        .rows()
+        .get(app.levels.last().map(|l| l.cursor).unwrap_or(0))
+        .map(|r| r.help.clone())
+        .unwrap_or_default();
+    frame.render_widget(
+        Paragraph::new(help)
+            .style(Style::default().fg(Color::Cyan))
+            .wrap(Wrap { trim: true }),
+        area,
+    );
+}
+
+fn draw_status(frame: &mut Frame, app: &App, area: Rect) {
+    let mut spans = Vec::new();
+    if app.dirty {
+        spans.push(Span::styled(
+            "[modified] ",
+            Style::default().fg(Color::Magenta),
+        ));
+    }
+    spans.push(Span::raw(app.status.clone()));
+    frame.render_widget(Paragraph::new(Line::from(spans)), area);
+}
+
+fn draw_keybar(frame: &mut Frame, app: &App, area: Rect) {
+    let text = if app.edit.is_some() {
+        "Enter apply  Esc cancel"
+    } else if app.modal.is_some() {
+        "Esc close"
+    } else {
+        match app.pane {
+            Pane::Sidebar => "↑/↓ section  Enter/→ open  s save  q quit",
+            Pane::Form => {
+                "↑/↓ move  Enter edit/toggle  Del/u reset  a add  ←/Esc back  s save  q quit"
+            }
+        }
+    };
+    frame.render_widget(
+        Paragraph::new(text).style(Style::default().fg(Color::DarkGray)),
+        area,
+    );
+}
+
+/// Split an edit buffer into spans with a visible cursor block.
+fn buffer_with_cursor(buffer: &str, cursor: usize) -> Vec<Span<'static>> {
+    let byte = buffer
+        .char_indices()
+        .nth(cursor)
+        .map(|(i, _)| i)
+        .unwrap_or(buffer.len());
+    let (before, rest) = buffer.split_at(byte);
+    let mut chars = rest.chars();
+    let at = chars.next();
+    let after: String = chars.collect();
+    let mut spans = vec![Span::raw(before.to_string())];
+    spans.push(Span::styled(
+        at.map(|c| c.to_string()).unwrap_or_else(|| " ".to_string()),
+        Style::default().bg(Color::White).fg(Color::Black),
+    ));
+    spans.push(Span::raw(after));
+    spans
+}
+
+/// A centered rectangle of at most `width` x `height` inside `area`.
+fn centered(area: Rect, width: u16, height: u16) -> Rect {
+    let w = width.min(area.width);
+    let h = height.min(area.height);
+    Rect {
+        x: area.x + (area.width - w) / 2,
+        y: area.y + (area.height - h) / 2,
+        width: w,
+        height: h,
+    }
+}
+
+fn draw_modal(frame: &mut Frame, _app: &App, modal: &Modal) {
+    let area = frame.area();
+    match modal {
+        Modal::DevicePicker {
+            output,
+            items,
+            cursor,
+            ..
+        } => {
+            let rect = centered(area, 70, (items.len() as u16 + 4).min(area.height));
+            frame.render_widget(Clear, rect);
+            let title = if *output {
+                "Select output device — Enter: choose  t: test  Esc: cancel"
+            } else {
+                "Select input device — Enter: choose  t: test  Esc: cancel"
+            };
+            let list_items: Vec<ListItem> = items
+                .iter()
+                .map(|item| {
+                    let name = item.name.as_deref().unwrap_or("(default)");
+                    ListItem::new(vec![
+                        Line::from(Span::styled(
+                            name.to_string(),
+                            Style::default().add_modifier(Modifier::BOLD),
+                        )),
+                        Line::from(Span::styled(
+                            format!("  {}", item.detail),
+                            Style::default().fg(Color::DarkGray),
+                        )),
+                    ])
+                })
+                .collect();
+            let list = List::new(list_items)
+                .block(Block::default().borders(Borders::ALL).title(title))
+                .highlight_style(Style::default().bg(Color::Blue).fg(Color::White));
+            let mut state = ListState::default().with_selected(Some(*cursor));
+            frame.render_stateful_widget(list, rect, &mut state);
+        }
+        Modal::OutputTest(state) => {
+            let channels = state.session.as_ref().map(|s| s.channels).unwrap_or(0);
+            let rect = centered(area, 64, (channels as u16 + 7).min(area.height));
+            frame.render_widget(Clear, rect);
+            let mut lines = Vec::new();
+            lines.push(Line::from(format!("Device: {}", state.device_label)));
+            if let Some(session) = &state.session {
+                lines.push(Line::from(format!("Negotiated: {}", session.description)));
+                lines.push(Line::from(Span::styled(
+                    "↑/↓ channel  Enter/Space play  b bass tone  a sweep all  Esc close",
+                    Style::default().fg(Color::DarkGray),
+                )));
+                let peaks = session.channel_peaks();
+                for ch in 0..session.channels {
+                    let alias = state
+                        .aliases
+                        .get(ch)
+                        .and_then(|a| a.clone())
+                        .map(|a| format!(" ({})", a))
+                        .unwrap_or_default();
+                    let peak = peaks.get(ch).copied().unwrap_or(0.0).clamp(0.0, 1.0);
+                    let marker = if ch == state.cursor { ">" } else { " " };
+                    lines.push(Line::from(vec![
+                        Span::raw(format!("{} ch {:>2}{:<12} ", marker, ch, alias)),
+                        Span::styled(
+                            level_bar(peak, 24),
+                            Style::default().fg(if peak > 0.9 { Color::Red } else { Color::Green }),
+                        ),
+                    ]));
+                }
+            }
+            if let Some(err) = &state.error {
+                lines.push(Line::from(Span::styled(
+                    err.clone(),
+                    Style::default().fg(Color::Red),
+                )));
+            }
+            frame.render_widget(
+                Paragraph::new(lines).block(
+                    Block::default()
+                        .borders(Borders::ALL)
+                        .title("Test output device"),
+                ),
+                rect,
+            );
+        }
+        Modal::InputTest(state) => {
+            let channels = state.session.as_ref().map(|s| s.channels).unwrap_or(0);
+            let rect = centered(area, 64, (channels as u16 + 6).min(area.height));
+            frame.render_widget(Clear, rect);
+            let mut lines = Vec::new();
+            lines.push(Line::from(format!("Device: {}", state.device_label)));
+            lines.push(Line::from(Span::styled(
+                "Speak into the microphone — Esc close",
+                Style::default().fg(Color::DarkGray),
+            )));
+            if let Some(session) = &state.session {
+                for (ch, peak) in session.peaks().iter().enumerate() {
+                    let peak = peak.clamp(0.0, 1.0);
+                    lines.push(Line::from(vec![
+                        Span::raw(format!("  ch {:>2} ", ch)),
+                        Span::styled(
+                            level_bar(peak, 32),
+                            Style::default().fg(if peak > 0.9 { Color::Red } else { Color::Green }),
+                        ),
+                    ]));
+                }
+            }
+            if let Some(err) = &state.error {
+                lines.push(Line::from(Span::styled(
+                    err.clone(),
+                    Style::default().fg(Color::Red),
+                )));
+            }
+            frame.render_widget(
+                Paragraph::new(lines).block(
+                    Block::default()
+                        .borders(Borders::ALL)
+                        .title("Test input device"),
+                ),
+                rect,
+            );
+        }
+        Modal::SaveDialog { buffer, cursor, .. } => {
+            let rect = centered(area, 70, 6);
+            frame.render_widget(Clear, rect);
+            let mut lines = Vec::new();
+            let mut spans = vec![Span::raw("Path: ")];
+            spans.extend(buffer_with_cursor(buffer, *cursor));
+            lines.push(Line::from(spans));
+            lines.push(Line::from(Span::styled(
+                "↑/↓ suggested paths  Enter: save  Esc: cancel",
+                Style::default().fg(Color::DarkGray),
+            )));
+            frame.render_widget(
+                Paragraph::new(lines).block(
+                    Block::default()
+                        .borders(Borders::ALL)
+                        .title("Save configuration"),
+                ),
+                rect,
+            );
+        }
+        Modal::Errors { title, errors } => {
+            let rect = centered(area, 76, (errors.len() as u16 + 4).min(area.height));
+            frame.render_widget(Clear, rect);
+            let mut lines: Vec<Line> = errors
+                .iter()
+                .map(|e| {
+                    Line::from(Span::styled(
+                        format!("• {}", e),
+                        Style::default().fg(Color::Red),
+                    ))
+                })
+                .collect();
+            lines.push(Line::from(Span::styled(
+                "press any key to continue",
+                Style::default().fg(Color::DarkGray),
+            )));
+            frame.render_widget(
+                Paragraph::new(lines)
+                    .wrap(Wrap { trim: true })
+                    .block(Block::default().borders(Borders::ALL).title(title.clone())),
+                rect,
+            );
+        }
+        Modal::ConfirmQuit => {
+            let rect = centered(area, 50, 3);
+            frame.render_widget(Clear, rect);
+            frame.render_widget(
+                Paragraph::new("Unsaved changes — quit anyway? (y/n)")
+                    .block(Block::default().borders(Borders::ALL).title("Confirm quit")),
+                rect,
+            );
+        }
+        Modal::LoadFailed { path, error } => {
+            let rect = centered(area, 76, 7);
+            frame.render_widget(Clear, rect);
+            let lines = vec![
+                Line::from(format!("Could not parse {}:", path.display())),
+                Line::from(Span::styled(error.clone(), Style::default().fg(Color::Red))),
+                Line::from(""),
+                Line::from("d: start from defaults (file untouched until saved)   q: quit"),
+            ];
+            frame.render_widget(
+                Paragraph::new(lines).wrap(Wrap { trim: true }).block(
+                    Block::default()
+                        .borders(Borders::ALL)
+                        .title("Config load failed"),
+                ),
+                rect,
+            );
+        }
+    }
+}
+
+/// A textual level meter: `width` cells, filled proportionally to `level` 0..=1.
+fn level_bar(level: f32, width: usize) -> String {
+    let filled = (level * width as f32).round() as usize;
+    let mut bar = String::with_capacity(width);
+    for i in 0..width {
+        bar.push(if i < filled.min(width) { '█' } else { '░' });
+    }
+    bar
+}

--- a/src/config_editor/mod.rs
+++ b/src/config_editor/mod.rs
@@ -1,0 +1,59 @@
+// ABOUTME: Interactive terminal UI for creating and editing the mqttaudio config file.
+// ABOUTME: Owns the terminal lifecycle and event loop; state lives in app, drawing in form.
+
+pub mod app;
+pub mod device_test;
+pub mod fields;
+pub mod form;
+pub mod save;
+
+use app::{App, Modal};
+use ratatui::crossterm::event::{self, Event};
+use save::{load_document, LoadOutcome};
+use std::time::Duration;
+
+/// Tick interval: drives meter refresh, sweep timing, and session polling.
+const TICK: Duration = Duration::from_millis(50);
+
+/// Run the interactive config editor. `config_path` is the --config argument:
+/// it is loaded when given (or the daemon's search paths otherwise) and is the
+/// default save target.
+pub fn run(config_path: Option<&str>) -> Result<(), Box<dyn std::error::Error>> {
+    let mut app = match load_document(config_path) {
+        LoadOutcome::Loaded { path, doc } => App::new(doc, Some(path)),
+        LoadOutcome::NotFound => {
+            let mut app = App::new(fields::ConfigDocument::new(), None);
+            if let Some(p) = config_path {
+                app.loaded_from = Some(std::path::PathBuf::from(p));
+                app.status = format!("New configuration (will save to {})", p);
+            }
+            app
+        }
+        LoadOutcome::Failed { path, error } => {
+            let mut app = App::new(fields::ConfigDocument::new(), Some(path.clone()));
+            app.modal = Some(Modal::LoadFailed { path, error });
+            app
+        }
+    };
+
+    let mut terminal = ratatui::init();
+    let result = run_loop(&mut terminal, &mut app);
+    ratatui::restore();
+    result
+}
+
+fn run_loop(
+    terminal: &mut ratatui::DefaultTerminal,
+    app: &mut App,
+) -> Result<(), Box<dyn std::error::Error>> {
+    while !app.quit {
+        terminal.draw(|frame| form::draw(frame, app))?;
+        if event::poll(TICK)? {
+            if let Event::Key(key) = event::read()? {
+                app.handle_key(key);
+            }
+        }
+        app.tick();
+    }
+    Ok(())
+}

--- a/src/config_editor/save.rs
+++ b/src/config_editor/save.rs
@@ -1,0 +1,130 @@
+// ABOUTME: Save and load logic for the config editor's sparse JSON document.
+// ABOUTME: Validates via Config::validate(), backs up the target, and writes atomically.
+
+use super::fields::ConfigDocument;
+use crate::config::Config;
+use std::path::{Path, PathBuf};
+
+/// What happened when a document was loaded.
+pub enum LoadOutcome {
+    /// A file was found and parsed.
+    Loaded { path: PathBuf, doc: ConfigDocument },
+    /// No config file exists; start fresh.
+    NotFound,
+    /// A file exists but could not be read or parsed.
+    Failed { path: PathBuf, error: String },
+}
+
+/// Load the document from `explicit_path` if given, else from the daemon's
+/// config search paths (./mqttaudio.json, the user config dir, /etc/mqttaudio).
+pub fn load_document(explicit_path: Option<&str>) -> LoadOutcome {
+    let path = match explicit_path {
+        Some(p) => PathBuf::from(p),
+        None => match Config::find_config_file() {
+            Some(p) => p,
+            None => return LoadOutcome::NotFound,
+        },
+    };
+    let text = match std::fs::read_to_string(&path) {
+        Ok(t) => t,
+        Err(e) => {
+            if explicit_path.is_none() {
+                return LoadOutcome::Failed {
+                    path,
+                    error: e.to_string(),
+                };
+            }
+            // An explicit path that does not exist yet is a fresh start aimed
+            // at that path; any other error is a real failure.
+            if e.kind() == std::io::ErrorKind::NotFound {
+                return LoadOutcome::NotFound;
+            }
+            return LoadOutcome::Failed {
+                path,
+                error: e.to_string(),
+            };
+        }
+    };
+    match ConfigDocument::parse(&text) {
+        Ok(doc) => LoadOutcome::Loaded { path, doc },
+        Err(error) => LoadOutcome::Failed { path, error },
+    }
+}
+
+/// Candidate save paths, most specific first: the path the file was loaded
+/// from (if any), then the daemon's search locations.
+pub fn save_path_candidates(loaded_from: Option<&Path>) -> Vec<PathBuf> {
+    let mut candidates = Vec::new();
+    if let Some(p) = loaded_from {
+        candidates.push(p.to_path_buf());
+    }
+    for p in [
+        PathBuf::from("./mqttaudio.json"),
+        dirs::config_dir()
+            .unwrap_or_else(|| PathBuf::from("."))
+            .join("mqttaudio")
+            .join("config.json"),
+        PathBuf::from("/etc/mqttaudio/config.json"),
+    ] {
+        if !candidates.contains(&p) {
+            candidates.push(p);
+        }
+    }
+    candidates
+}
+
+/// The result of a successful save.
+#[derive(Debug)]
+pub struct SaveOutcome {
+    /// Path of the backup made of the previous file, if one existed.
+    pub backup: Option<PathBuf>,
+}
+
+/// Validate the document and write it to `path` atomically (temp file + rename
+/// in the target directory), backing up an existing file to `<path>.bak` first.
+/// Refuses to write when the document does not deserialize or fails
+/// `Config::validate()`, returning the error list.
+pub fn save_document(doc: &ConfigDocument, path: &Path) -> Result<SaveOutcome, Vec<String>> {
+    let config = doc.to_config().map_err(|e| vec![e])?;
+    config.validate()?;
+
+    let dir = match path.parent() {
+        Some(p) if !p.as_os_str().is_empty() => p.to_path_buf(),
+        _ => PathBuf::from("."),
+    };
+    std::fs::create_dir_all(&dir)
+        .map_err(|e| vec![format!("could not create {}: {}", dir.display(), e)])?;
+
+    let mut backup = None;
+    if path.exists() {
+        let bak = path.with_extension(format!(
+            "{}{}bak",
+            path.extension()
+                .map(|e| e.to_string_lossy().to_string())
+                .unwrap_or_default(),
+            if path.extension().is_some() { "." } else { "" }
+        ));
+        std::fs::copy(path, &bak)
+            .map_err(|e| vec![format!("could not back up to {}: {}", bak.display(), e)])?;
+        backup = Some(bak);
+    }
+
+    let tmp = dir.join(format!(
+        ".{}.tmp",
+        path.file_name()
+            .map(|n| n.to_string_lossy().to_string())
+            .unwrap_or_else(|| "mqttaudio.json".to_string())
+    ));
+    std::fs::write(&tmp, doc.to_pretty_string())
+        .map_err(|e| vec![format!("could not write {}: {}", tmp.display(), e)])?;
+    std::fs::rename(&tmp, path).map_err(|e| {
+        let _ = std::fs::remove_file(&tmp);
+        vec![format!(
+            "could not move into place at {}: {}",
+            path.display(),
+            e
+        )]
+    })?;
+
+    Ok(SaveOutcome { backup })
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,5 +36,6 @@ pub mod mqtt {
 pub mod http;
 
 pub mod config;
+pub mod config_editor;
 pub mod rt_engine;
 pub mod voice;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@
 mod audio;
 mod cache;
 mod config;
+mod config_editor;
 mod http;
 mod mqtt;
 mod rt_engine;
@@ -49,6 +50,10 @@ struct Args {
     /// Enable verbose logging
     #[arg(short, long)]
     verbose: bool,
+
+    /// Launch the interactive configuration editor and exit
+    #[arg(long)]
+    configure: bool,
 
     /// List available audio output devices and exit
     #[arg(long)]
@@ -120,6 +125,16 @@ where
 #[tokio::main]
 async fn main() {
     let args = Args::parse();
+
+    // Handle --configure before logging init: a tracing subscriber writing to
+    // stdout would corrupt the editor's raw-mode alternate screen.
+    if args.configure {
+        if let Err(e) = config_editor::run(args.config.as_deref()) {
+            eprintln!("Configuration editor error: {}", e);
+            std::process::exit(1);
+        }
+        return;
+    }
 
     // Load configuration
     let mut config = match config::Config::load_from_path_or_default(args.config.as_deref()) {

--- a/tests/config_editor_device_test.rs
+++ b/tests/config_editor_device_test.rs
@@ -1,0 +1,62 @@
+// ABOUTME: Lane B (real device) tests for the config editor's live device test sessions.
+// ABOUTME: Gated behind #[ignore] + MQTTAUDIO_DEVICE_TESTS so Lane A (no device) skips them.
+
+use mqttaudio::config::Config;
+use mqttaudio::config_editor::device_test::{start_input_test, start_output_test, TEST_TONE_HZ};
+
+/// Open the default output device through the editor's test session, play a
+/// tone on channel 0 through the real mixer pathway, and tear down cleanly.
+#[test]
+#[ignore] // Lane B only (real device): `cargo test -- --ignored` with MQTTAUDIO_DEVICE_TESTS=1
+fn output_test_session_plays_a_tone() {
+    if std::env::var("MQTTAUDIO_DEVICE_TESTS").is_err() {
+        eprintln!("skipping: set MQTTAUDIO_DEVICE_TESTS=1 to run real-device smoke tests");
+        return;
+    }
+
+    let config = Config::default();
+    let mut session = start_output_test(&config, None).expect("open the default output device");
+    assert!(session.channels > 0);
+    assert!(!session.description.is_empty());
+
+    session
+        .play_tone_on_channel(0, TEST_TONE_HZ)
+        .expect("queue a tone on channel 0");
+
+    // Let the tone mix; poll the off-RT rings like the editor's tick does.
+    for _ in 0..10 {
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        session.poll().expect("no stream error during the tone");
+    }
+
+    // Telemetry meters saw signal on channel 0 while the tone played.
+    let peaks = session.channel_peaks();
+    assert_eq!(peaks.len(), session.channels);
+
+    // Out-of-range channels are rejected, not panicked on.
+    assert!(session
+        .play_tone_on_channel(session.channels, TEST_TONE_HZ)
+        .is_err());
+
+    drop(session);
+}
+
+/// Open the default input device through the daemon's real capture path and
+/// meter it briefly. The open is the hard assertion; captured levels depend on
+/// the host's microphone permissions and ambient signal.
+#[test]
+#[ignore] // Lane B only (real device): `cargo test -- --ignored` with MQTTAUDIO_DEVICE_TESTS=1
+fn input_test_session_captures_without_panicking() {
+    if std::env::var("MQTTAUDIO_DEVICE_TESTS").is_err() {
+        eprintln!("skipping: set MQTTAUDIO_DEVICE_TESTS=1 to run real-device smoke tests");
+        return;
+    }
+
+    let mut session = start_input_test(None, 20, 48000).expect("open the default input device");
+    assert!(session.channels > 0);
+    for _ in 0..10 {
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        session.poll();
+    }
+    assert_eq!(session.peaks().len(), session.channels);
+}

--- a/tests/config_editor_test.rs
+++ b/tests/config_editor_test.rs
@@ -1,0 +1,627 @@
+// ABOUTME: Tests for the config editor's document model, field registry, save logic,
+// ABOUTME: tone generation, key-driven editing behavior, and rendering smoke checks.
+
+use mqttaudio::config::Config;
+use mqttaudio::config_editor::app::{App, Modal};
+use mqttaudio::config_editor::device_test::generate_tone;
+use mqttaudio::config_editor::fields::{
+    parse_field_value, path_of, ConfigDocument, FieldKind, Section, Seg, SubFieldSpec, REGISTRY,
+};
+use mqttaudio::config_editor::form;
+use mqttaudio::config_editor::save::{save_document, save_path_candidates};
+use ratatui::backend::TestBackend;
+use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use ratatui::Terminal;
+use serde_json::{json, Value};
+
+// --- Document model ---
+
+#[test]
+fn set_creates_intermediate_objects_and_get_reads_back() {
+    let mut doc = ConfigDocument::new();
+    doc.set(&path_of(&["mqtt", "server"]), json!("broker.local"));
+    assert_eq!(
+        doc.get(&path_of(&["mqtt", "server"])),
+        Some(&json!("broker.local"))
+    );
+    assert!(doc.get(&path_of(&["mqtt", "port"])).is_none());
+}
+
+#[test]
+fn unset_removes_key_and_prunes_empty_parents() {
+    let mut doc = ConfigDocument::new();
+    doc.set(&path_of(&["mqtt", "tls", "ca_path"]), json!("/ca.pem"));
+    doc.unset(&path_of(&["mqtt", "tls", "ca_path"]));
+    // Both the emptied tls object and the emptied mqtt object are pruned.
+    assert!(doc.root().as_object().unwrap().is_empty());
+}
+
+#[test]
+fn unset_leaves_nonempty_parents_alone() {
+    let mut doc = ConfigDocument::new();
+    doc.set(&path_of(&["mqtt", "server"]), json!("a"));
+    doc.set(&path_of(&["mqtt", "port"]), json!(1884));
+    doc.unset(&path_of(&["mqtt", "port"]));
+    assert_eq!(doc.get(&path_of(&["mqtt", "server"])), Some(&json!("a")));
+}
+
+#[test]
+fn untouched_defaults_never_appear_in_output() {
+    let mut doc = ConfigDocument::new();
+    doc.set(&path_of(&["mqtt", "topic"]), json!("audio/#"));
+    let text = doc.to_pretty_string();
+    let parsed: Value = serde_json::from_str(&text).unwrap();
+    let obj = parsed.as_object().unwrap();
+    assert_eq!(
+        obj.len(),
+        1,
+        "only the explicitly-set key is written: {text}"
+    );
+    assert_eq!(parsed["mqtt"]["topic"], json!("audio/#"));
+}
+
+#[test]
+fn unknown_keys_pass_through_load_and_save() {
+    let original = r#"{
+        "_comment": "hand-written notes survive",
+        "mqtt": { "topic": "audio/#", "_note": "nested too" }
+    }"#;
+    let mut doc = ConfigDocument::parse(original).unwrap();
+    doc.set(&path_of(&["mqtt", "server"]), json!("broker"));
+    let saved: Value = serde_json::from_str(&doc.to_pretty_string()).unwrap();
+    assert_eq!(saved["_comment"], json!("hand-written notes survive"));
+    assert_eq!(saved["mqtt"]["_note"], json!("nested too"));
+    assert_eq!(saved["mqtt"]["server"], json!("broker"));
+}
+
+#[test]
+fn document_deserializes_with_daemon_defaults() {
+    let mut doc = ConfigDocument::new();
+    doc.set(&path_of(&["mqtt", "topic"]), json!("audio/#"));
+    let config = doc.to_config().unwrap();
+    assert_eq!(config.mqtt.topic.as_deref(), Some("audio/#"));
+    assert_eq!(config.audio.sample_rate, 48000);
+    assert_eq!(config.audio.buffer_size, 512);
+}
+
+#[test]
+fn push_appends_and_unset_removes_list_elements() {
+    let mut doc = ConfigDocument::new();
+    let path = path_of(&["cache", "precache"]);
+    doc.push(&path, json!("a.wav"));
+    doc.push(&path, json!("b.wav"));
+    assert_eq!(doc.list_len(&path), 2);
+    let mut item0 = path.clone();
+    item0.push(Seg::Idx(0));
+    doc.unset(&item0);
+    assert_eq!(doc.list_len(&path), 1);
+    let mut item = path.clone();
+    item.push(Seg::Idx(0));
+    assert_eq!(doc.get(&item), Some(&json!("b.wav")));
+}
+
+// --- Field value parsing ---
+
+#[test]
+fn parse_uint_enforces_bounds() {
+    let kind = FieldKind::UInt { min: 64, max: 8192 };
+    assert_eq!(parse_field_value(&kind, "512").unwrap(), Some(json!(512)));
+    assert!(parse_field_value(&kind, "32").is_err());
+    assert!(parse_field_value(&kind, "9000").is_err());
+    assert!(parse_field_value(&kind, "abc").is_err());
+}
+
+#[test]
+fn parse_float_enforces_bounds_and_finiteness() {
+    let kind = FieldKind::Float {
+        min: -60.0,
+        max: 0.0,
+    };
+    assert_eq!(parse_field_value(&kind, "-1.0").unwrap(), Some(json!(-1.0)));
+    assert!(parse_field_value(&kind, "1.0").is_err());
+    assert!(parse_field_value(&kind, "NaN").is_err());
+}
+
+#[test]
+fn parse_optional_text_empty_means_unset() {
+    assert_eq!(
+        parse_field_value(&FieldKind::OptionalText, "").unwrap(),
+        None
+    );
+    assert_eq!(
+        parse_field_value(&FieldKind::OptionalText, "x").unwrap(),
+        Some(json!("x"))
+    );
+    assert!(parse_field_value(&FieldKind::Text, "").is_err());
+}
+
+#[test]
+fn parse_enum_accepts_only_options() {
+    let kind = FieldKind::Enum(&["text", "json"]);
+    assert_eq!(
+        parse_field_value(&kind, "JSON").unwrap(),
+        Some(json!("json"))
+    );
+    assert!(parse_field_value(&kind, "xml").is_err());
+}
+
+#[test]
+fn parse_channel_ref_distinguishes_index_and_alias() {
+    assert_eq!(
+        parse_field_value(&FieldKind::ChannelRef, "3").unwrap(),
+        Some(json!(3))
+    );
+    assert_eq!(
+        parse_field_value(&FieldKind::ChannelRef, "lfe").unwrap(),
+        Some(json!("lfe"))
+    );
+}
+
+#[test]
+fn parse_json_value_validates() {
+    assert_eq!(
+        parse_field_value(&FieldKind::MapToJson, r#"{"volume": 0.5}"#).unwrap(),
+        Some(json!({"volume": 0.5}))
+    );
+    assert!(parse_field_value(&FieldKind::MapToJson, "{nope").is_err());
+}
+
+// --- Save ---
+
+#[test]
+fn save_writes_backs_up_and_validates() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("mqttaudio.json");
+
+    let mut doc = ConfigDocument::new();
+    doc.set(&path_of(&["mqtt", "topic"]), json!("audio/#"));
+    let outcome = save_document(&doc, &path).unwrap();
+    assert!(outcome.backup.is_none());
+    let first = std::fs::read_to_string(&path).unwrap();
+    assert!(first.ends_with('\n'));
+
+    // Second save backs up the first.
+    doc.set(&path_of(&["mqtt", "server"]), json!("broker"));
+    let outcome = save_document(&doc, &path).unwrap();
+    let backup = outcome.backup.expect("backup of existing file");
+    assert_eq!(std::fs::read_to_string(&backup).unwrap(), first);
+
+    // The saved file loads as a valid daemon config.
+    let config = Config::from_file(&path).unwrap();
+    assert_eq!(config.mqtt.server, "broker");
+}
+
+#[test]
+fn save_refuses_invalid_config_and_leaves_file_untouched() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("mqttaudio.json");
+
+    let mut doc = ConfigDocument::new();
+    doc.set(&path_of(&["mqtt", "topic"]), json!("audio/#"));
+    save_document(&doc, &path).unwrap();
+    let before = std::fs::read_to_string(&path).unwrap();
+
+    // No mqtt.topic and no http: validate() rejects it.
+    let mut bad = ConfigDocument::new();
+    bad.set(&path_of(&["audio", "sample_rate"]), json!(44100));
+    bad.unset(&path_of(&["mqtt", "topic"]));
+    let errors = save_document(&bad, &path).unwrap_err();
+    assert!(
+        errors.iter().any(|e| e.contains("mqtt.topic")),
+        "expected the topic/http validation error, got: {errors:?}"
+    );
+    assert_eq!(std::fs::read_to_string(&path).unwrap(), before);
+}
+
+#[test]
+fn save_refuses_undeserializable_document() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("mqttaudio.json");
+    let doc = ConfigDocument::parse(r#"{ "mqtt": { "port": "not-a-number" } }"#).unwrap();
+    assert!(save_document(&doc, &path).is_err());
+    assert!(!path.exists());
+}
+
+#[test]
+fn save_path_candidates_start_with_loaded_path() {
+    let loaded = std::path::Path::new("/tmp/custom.json");
+    let candidates = save_path_candidates(Some(loaded));
+    assert_eq!(candidates[0], loaded);
+    assert!(candidates.len() > 1);
+}
+
+// --- Tone generation ---
+
+#[test]
+fn tone_has_correct_length_fades_and_peak() {
+    let tone = generate_tone(440.0, 48000, 500, 8, 0.5);
+    assert_eq!(tone.len(), 24000);
+    // Fade edges start and end at silence.
+    assert_eq!(tone[0], 0.0);
+    assert_eq!(tone[tone.len() - 1], 0.0);
+    // Peak stays at or below the requested amplitude, and the body is audible.
+    let peak = tone.iter().fold(0.0f32, |m, s| m.max(s.abs()));
+    assert!(peak <= 0.5 + 1e-6, "peak {peak}");
+    assert!(peak >= 0.45, "peak {peak}");
+    // Rising zero crossings approximate the requested frequency (440 Hz over
+    // 0.5 s means ~220 full cycles).
+    let crossings = tone
+        .windows(2)
+        .filter(|w| w[0] < 0.0 && w[1] >= 0.0)
+        .count();
+    assert!((215..=225).contains(&crossings), "crossings {crossings}");
+}
+
+// --- Registry coverage: every config field must be editable ---
+
+/// Collect every leaf path of a JSON value.
+fn leaf_paths(value: &Value, prefix: Vec<String>, out: &mut Vec<Vec<String>>) {
+    match value {
+        Value::Object(map) => {
+            if map.is_empty() {
+                out.push(prefix);
+            } else {
+                for (k, v) in map {
+                    let mut p = prefix.clone();
+                    p.push(k.clone());
+                    leaf_paths(v, p, out);
+                }
+            }
+        }
+        Value::Array(arr) => {
+            if arr.is_empty() {
+                out.push(prefix);
+            } else {
+                for (i, v) in arr.iter().enumerate() {
+                    let mut p = prefix.clone();
+                    p.push(i.to_string());
+                    leaf_paths(v, p, out);
+                }
+            }
+        }
+        _ => out.push(prefix),
+    }
+}
+
+/// Whether `kind` covers the path `rest` below a spec's own path.
+fn kind_covers(kind: &FieldKind, rest: &[String]) -> bool {
+    match kind {
+        FieldKind::StringList | FieldKind::ChannelRefList => {
+            rest.is_empty() || (rest.len() == 1 && rest[0].parse::<usize>().is_ok())
+        }
+        FieldKind::MapToUInt | FieldKind::MapToFloat { .. } => rest.len() <= 1,
+        // Macro values are arbitrary JSON: anything below the key is covered.
+        FieldKind::MapToJson => true,
+        FieldKind::MemoryBudget => {
+            rest.is_empty()
+                || (rest.len() == 1
+                    && ["mode", "fraction", "floor_mb", "ceiling_mb", "mb"]
+                        .contains(&rest[0].as_str()))
+        }
+        FieldKind::Flag => rest.is_empty(),
+        FieldKind::StructList(specs) => {
+            if rest.is_empty() {
+                return true;
+            }
+            // First segment is the list index, then a known sub-field.
+            if rest[0].parse::<usize>().is_err() {
+                return false;
+            }
+            let rest = &rest[1..];
+            if rest.is_empty() {
+                return true;
+            }
+            struct_covers(specs, rest)
+        }
+        // Scalar kinds cover exactly their own path.
+        _ => rest.is_empty(),
+    }
+}
+
+fn struct_covers(specs: &[SubFieldSpec], rest: &[String]) -> bool {
+    specs
+        .iter()
+        .any(|s| s.key == rest[0] && kind_covers(&s.kind, &rest[1..]))
+}
+
+fn covered_by_registry(path: &[String]) -> bool {
+    REGISTRY.iter().any(|spec| {
+        if path.len() < spec.path.len() {
+            return false;
+        }
+        if !spec.path.iter().zip(path.iter()).all(|(a, b)| a == b) {
+            return false;
+        }
+        kind_covers(&spec.kind, &path[spec.path.len()..])
+    })
+}
+
+#[test]
+fn registry_covers_every_config_field() {
+    // The default config exposes every always-serialized field; the populated
+    // fixture adds the skip_serializing_if optionals and one element of every
+    // collection. A new config field fails this test until the editor gets a
+    // binding for it.
+    let default = serde_json::to_value(Config::default()).unwrap();
+    let populated: Value = json!({
+        "schema_version": 1,
+        "mqtt": {
+            "username": "user",
+            "password": "secret",
+            "tls": { "ca_path": "/ca.pem" }
+        },
+        "audio": {
+            "device": "hw:0,0",
+            "channels": 8,
+            "channel_aliases": { "lfe": 3 },
+            "channel_volumes": { "0": 0.9 }
+        },
+        "cache": {
+            "precache": ["a.wav"],
+            "memory_budget": { "mode": "auto", "fraction": 0.4, "floor_mb": 128, "ceiling_mb": 1024 }
+        },
+        "security": { "allowed_directories": ["/srv/audio"] },
+        "logging": { "mqtt_topic": "audio/logs" },
+        "http": { "auth_token": "longenough" },
+        "ducking_rules": [
+            { "primary_voice": "voice", "ducked_voices": ["music"], "target_volume": 0.2, "fade_duration_ms": 300 }
+        ],
+        "bass_management": { "source_channels": [0, 1] },
+        "inputs": [
+            { "device": "mic", "volume": 0.8, "voice_id": "mic", "latency_ms": 20,
+              "routes": [ { "source_channel": 0, "dest_channel": "lfe" } ] }
+        ],
+        "macros": { "boom": { "volume": 1.0 } }
+    });
+    // Sanity check: the populated fixture must itself deserialize, so the test
+    // breaks when the fixture drifts from the real schema.
+    let _: Config = serde_json::from_value(populated.clone()).unwrap();
+
+    let mut paths = Vec::new();
+    leaf_paths(&default, Vec::new(), &mut paths);
+    leaf_paths(&populated, Vec::new(), &mut paths);
+
+    let missing: Vec<String> = paths
+        .iter()
+        .filter(|p| !covered_by_registry(p))
+        .map(|p| p.join("."))
+        .collect();
+    assert!(
+        missing.is_empty(),
+        "config fields without an editor binding: {missing:?}"
+    );
+}
+
+// --- Key-driven editing behavior ---
+
+fn key(code: KeyCode) -> KeyEvent {
+    KeyEvent::new(code, KeyModifiers::NONE)
+}
+
+fn new_app() -> App {
+    App::new(ConfigDocument::new(), None)
+}
+
+fn goto_section(app: &mut App, section: Section) {
+    let idx = Section::ALL.iter().position(|s| *s == section).unwrap();
+    while app.section_idx < idx {
+        app.handle_key(key(KeyCode::Down));
+    }
+    app.handle_key(key(KeyCode::Enter)); // focus the form
+}
+
+#[test]
+fn typing_a_value_sets_it_in_the_document() {
+    let mut app = new_app();
+    goto_section(&mut app, Section::Mqtt);
+    app.handle_key(key(KeyCode::Enter)); // edit mqtt.server
+    for c in "broker.local".chars() {
+        app.handle_key(key(KeyCode::Char(c)));
+    }
+    app.handle_key(key(KeyCode::Enter));
+    assert_eq!(
+        app.doc.get(&path_of(&["mqtt", "server"])),
+        Some(&json!("broker.local"))
+    );
+    assert!(app.dirty);
+}
+
+#[test]
+fn toggling_a_bool_sets_the_inverse_of_the_default() {
+    let mut app = new_app();
+    goto_section(&mut app, Section::Cache);
+    // First row of Cache is "enabled" (default true).
+    app.handle_key(key(KeyCode::Enter));
+    assert_eq!(
+        app.doc.get(&path_of(&["cache", "enabled"])),
+        Some(&json!(false))
+    );
+}
+
+#[test]
+fn cycling_an_enum_walks_its_options() {
+    let mut app = new_app();
+    goto_section(&mut app, Section::Logging);
+    // logging.level: info -> debug (next after the default).
+    app.handle_key(key(KeyCode::Enter));
+    assert_eq!(
+        app.doc.get(&path_of(&["logging", "level"])),
+        Some(&json!("debug"))
+    );
+}
+
+#[test]
+fn delete_resets_a_field_to_default() {
+    let mut app = new_app();
+    goto_section(&mut app, Section::Mqtt);
+    app.handle_key(key(KeyCode::Enter));
+    for c in "x".chars() {
+        app.handle_key(key(KeyCode::Char(c)));
+    }
+    app.handle_key(key(KeyCode::Enter));
+    assert!(app.doc.get(&path_of(&["mqtt", "server"])).is_some());
+    app.handle_key(key(KeyCode::Delete));
+    assert!(app.doc.get(&path_of(&["mqtt", "server"])).is_none());
+}
+
+#[test]
+fn invalid_input_keeps_the_edit_open_with_an_error() {
+    let mut app = new_app();
+    goto_section(&mut app, Section::Audio);
+    app.handle_key(key(KeyCode::Down)); // sample_rate
+    app.handle_key(key(KeyCode::Enter));
+    for c in "99".chars() {
+        app.handle_key(key(KeyCode::Char(c)));
+    }
+    app.handle_key(key(KeyCode::Enter));
+    assert!(app.edit.as_ref().and_then(|e| e.error.as_ref()).is_some());
+    assert!(app.doc.get(&path_of(&["audio", "sample_rate"])).is_none());
+    app.handle_key(key(KeyCode::Esc));
+    assert!(app.edit.is_none());
+}
+
+#[test]
+fn memory_budget_cycles_through_modes() {
+    let mut app = new_app();
+    goto_section(&mut app, Section::Cache);
+    let path = path_of(&["cache", "memory_budget"]);
+    // Move to the memory_budget row by label.
+    let idx = app
+        .rows()
+        .iter()
+        .position(|r| r.label == "memory_budget")
+        .unwrap();
+    for _ in 0..idx {
+        app.handle_key(key(KeyCode::Down));
+    }
+    app.handle_key(key(KeyCode::Enter));
+    assert_eq!(app.doc.get(&path).unwrap()["mode"], json!("auto"));
+    app.handle_key(key(KeyCode::Enter));
+    assert_eq!(app.doc.get(&path).unwrap()["mode"], json!("explicit"));
+    app.handle_key(key(KeyCode::Enter));
+    assert_eq!(app.doc.get(&path).unwrap()["mode"], json!("unlimited"));
+    app.handle_key(key(KeyCode::Enter));
+    assert!(app.doc.get(&path).is_none());
+}
+
+#[test]
+fn adding_a_map_entry_prompts_key_then_value() {
+    let mut app = new_app();
+    goto_section(&mut app, Section::Audio);
+    let idx = app
+        .rows()
+        .iter()
+        .position(|r| r.label == "channel_aliases")
+        .unwrap();
+    for _ in 0..idx {
+        app.handle_key(key(KeyCode::Down));
+    }
+    app.handle_key(key(KeyCode::Enter)); // open the map level
+    app.handle_key(key(KeyCode::Char('a')));
+    for c in "lfe".chars() {
+        app.handle_key(key(KeyCode::Char(c)));
+    }
+    app.handle_key(key(KeyCode::Enter)); // commit key, prompts for value
+    for c in "3".chars() {
+        app.handle_key(key(KeyCode::Char(c)));
+    }
+    app.handle_key(key(KeyCode::Enter));
+    assert_eq!(
+        app.doc.get(&path_of(&["audio", "channel_aliases", "lfe"])),
+        Some(&json!(3))
+    );
+}
+
+#[test]
+fn adding_a_ducking_rule_creates_a_deserializable_skeleton() {
+    let mut app = new_app();
+    goto_section(&mut app, Section::Ducking);
+    app.handle_key(key(KeyCode::Enter)); // open the rule list
+    app.handle_key(key(KeyCode::Char('a'))); // add a rule (opens its sub-form)
+    let mut item = path_of(&["ducking_rules"]);
+    item.push(Seg::Idx(0));
+    assert!(app.doc.get(&item).is_some());
+    // The skeleton deserializes (all DuckingRule fields are required).
+    app.doc.to_config().unwrap();
+}
+
+#[test]
+fn quit_with_unsaved_changes_asks_for_confirmation() {
+    let mut app = new_app();
+    goto_section(&mut app, Section::Mqtt);
+    app.handle_key(key(KeyCode::Enter));
+    app.handle_key(key(KeyCode::Char('x')));
+    app.handle_key(key(KeyCode::Enter));
+    app.handle_key(key(KeyCode::Char('q')));
+    assert!(matches!(app.modal, Some(Modal::ConfirmQuit)));
+    assert!(!app.quit);
+    app.handle_key(key(KeyCode::Char('y')));
+    assert!(app.quit);
+}
+
+// --- Rendering smoke tests ---
+
+fn render(app: &App) {
+    let backend = TestBackend::new(100, 30);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal.draw(|frame| form::draw(frame, app)).unwrap();
+}
+
+#[test]
+fn every_section_renders() {
+    let mut app = new_app();
+    render(&app);
+    for _ in 1..Section::ALL.len() {
+        app.handle_key(key(KeyCode::Down));
+        render(&app);
+    }
+}
+
+#[test]
+fn nested_levels_render() {
+    let mut app = new_app();
+    goto_section(&mut app, Section::Inputs);
+    app.handle_key(key(KeyCode::Enter)); // inputs list
+    render(&app);
+    app.handle_key(key(KeyCode::Char('a'))); // add input -> sub-form
+    render(&app);
+    // Open the routes list inside the input.
+    let idx = app.rows().iter().position(|r| r.label == "routes").unwrap();
+    for _ in 0..idx {
+        app.handle_key(key(KeyCode::Down));
+    }
+    app.handle_key(key(KeyCode::Enter));
+    render(&app);
+    app.handle_key(key(KeyCode::Char('a'))); // add a route -> route sub-form
+    render(&app);
+}
+
+#[test]
+fn edit_prompt_and_modals_render() {
+    let mut app = new_app();
+    goto_section(&mut app, Section::Mqtt);
+    app.handle_key(key(KeyCode::Enter)); // editing mqtt.server
+    app.handle_key(key(KeyCode::Char('x')));
+    render(&app);
+    app.handle_key(key(KeyCode::Esc));
+
+    app.modal = Some(Modal::Errors {
+        title: "Cannot save".to_string(),
+        errors: vec!["something is wrong".to_string()],
+    });
+    render(&app);
+
+    app.modal = Some(Modal::ConfirmQuit);
+    render(&app);
+
+    app.modal = Some(Modal::LoadFailed {
+        path: "/tmp/x.json".into(),
+        error: "expected value at line 1".to_string(),
+    });
+    render(&app);
+
+    app.handle_key(key(KeyCode::Char('d'))); // start from defaults
+    app.handle_key(key(KeyCode::Char('s'))); // save dialog
+    assert!(matches!(app.modal, Some(Modal::SaveDialog { .. })));
+    render(&app);
+}


### PR DESCRIPTION
## Summary

Adds a complete interactive configuration editor accessible via `mqttaudio --configure`. The editor is a full-screen terminal UI (using ratatui) that allows users to create and edit the JSON configuration file without manually writing JSON.

## Key Changes

- **New `config_editor` module** with five main components:
  - `app.rs`: Application state machine handling section navigation, field editing, modals (device picker, test sessions, save dialog), and keyboard input
  - `fields.rs`: Declarative field registry mapping every config field to JSON paths, edit kinds, bounds, and help text; sparse JSON document model that preserves unknown keys and comments
  - `form.rs`: Pure ratatui rendering layer (sidebar, forms, modals, help text, status bar)
  - `save.rs`: Document load/save with validation, atomic writes, and backup creation
  - `device_test.rs`: Live output test sessions (real mixer pathway with test tones) and input level metering

- **Device enumeration improvements** in `audio/engine.rs` and `audio/input.rs`:
  - Structured `output_device_list()` / `input_device_list()` extracted from the print-only listings (`--list-devices` / `--list-inputs` output unchanged)

- **CLI integration**:
  - New `--configure` flag in `main.rs` to launch the editor
  - Updated documentation in README.md and docs/configuration.md

- **`config.example.json` schema fix**: the example still documented the removed `audio.channel_names` field (index→name); both occurrences now use the live `audio.channel_aliases` mechanism with the correct name→index direction, and the example loads cleanly through the real parser/validator

- **Comprehensive test coverage** in `tests/config_editor_test.rs`:
  - Document model (set/get/unset, sparse JSON, unknown key preservation)
  - Field value parsing (bounds checking, type validation)
  - Save/load with validation and backup
  - Tone generation
  - Key-driven editing behavior
  - Registry coverage test: fails when a future config field is added without an editor binding
  - Rendering smoke checks

- **Device test integration** in `tests/config_editor_device_test.rs` (Lane B, real device tests)

## Notable Implementation Details

- The sparse JSON document model preserves untouched fields and unknown keys/comments, so only explicitly-set values are written on save
- Memory budget fields show mode-specific sub-fields (auto vs. explicit) dynamically
- Device picker integrates with real audio pathway for live testing (plays tones through actual mixer with channel gains, master gain, limiter, bass management)
- Keyboard-driven navigation with Esc/Enter/arrow keys; modals for device selection, test sessions, and save confirmation
- All config fields are declaratively registered with validation rules, help text, and JSON paths
- Input device enumeration handles edge cases (ALSA plugins, missing capabilities) gracefully

https://claude.ai/code/session_01TPHe15AZST3AUE29UemdQy