### PR TITLE
Fix microphone capture on multichannel interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,9 +27,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   device.
 - **Voice volume ramping on live inputs**: a fade no longer stalls while the
   input is starved.
+- **`audio.channel_volumes` had no effect**: the per-channel calibration was
+  parsed and validated but never applied to the output. It is now applied to
+  the finished mix, after bass management.
 
 ### Added
 
+- `fadeall` command, fading every playing sample out over a given time and
+  stopping it, alongside the existing `stopall`. Available over MQTT
+  (`{"command": "fadeall", "time": 2000}`, defaulting to 1000 ms) and as
+  `POST /fadeall`.
+- Gains above unity. Volume controls now accept up to 4.0 (+12 dB) instead of
+  stopping at 1.0, so a quiet microphone, a voice, an individual sample or an
+  underpowered subwoofer channel can be lifted rather than only attenuated.
+  Applies to `inputs[].volume`, `audio.channel_volumes`, the `play`, `volume`,
+  `voice_volume` and `input_volume` commands. The mixer still saturates its
+  output, so a boost clips rather than wrapping.
+- `audio.channel_volumes` keys may be a channel number, an
+  `audio.channel_aliases` name, or an `audio.channel_names` label, and an
+  unresolvable key is now a validation error rather than being ignored.
 - `inputs[].channels` and `inputs[].sample_rate` to control how a capture
   stream is opened. By default the stream opens with the smallest channel count
   the routes need, at the output sample rate so no resampling is required.
@@ -38,6 +54,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A clear startup error when a device offers no f32 capture format, naming the
   `plughw:` alias as the fix, and when routing references a channel the device
   cannot reach.
+
+### Changed
+
+- Unknown channel names in routing now explain the `audio.channel_names` /
+  `audio.channel_aliases` split. A name defined only in `channel_names` is
+  reported with the `channel_aliases` entry needed to fix it, instead of a bare
+  "Unknown channel alias".
+- `play` volume is clamped to the gain limit; previously it was passed through
+  unbounded while every other volume control clamped at 1.0.
 
 ## [2.0.0] - 2025-10-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,40 @@ All notable changes to mqttaudio will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Microphone capture on multichannel interfaces**: input devices with more
+  than 16 channels lost part of every frame, which rotated the channel routing
+  and grew a residue in the ring buffer until it overflowed continuously. All
+  capture channels are now readable and routable.
+- **Channel alignment under load**: an overrun could write a partial frame into
+  the capture ring buffer, permanently shifting which microphone reached which
+  speaker. Only whole frames are transferred now, so an overrun costs audio
+  rather than correctness.
+- **Capture latency drift**: a capture clock faster than the output clock built
+  an unbounded backlog. Excess backlog is now trimmed in whole frames.
+- **Realtime safety of capture callbacks**: the callbacks no longer allocate,
+  resample into freshly allocated buffers, or write log lines, all of which
+  stalled the capture thread and caused the overruns they reported.
+- **Input device naming**: input devices are now resolved by ALSA card the same
+  way output devices are, so `"hw:CARD=UMC1820, DEV=0"` matches the enumerated
+  device.
+- **Voice volume ramping on live inputs**: a fade no longer stalls while the
+  input is starved.
+
+### Added
+
+- `inputs[].channels` and `inputs[].sample_rate` to control how a capture
+  stream is opened. By default the stream opens with the smallest channel count
+  the routes need, at the output sample rate so no resampling is required.
+- Input health counters (backlog, overruns, trims, starvation) reported through
+  `GET /status/inputs` and logged every 10 seconds when non-zero.
+- A clear startup error when a device offers no f32 capture format, naming the
+  `plughw:` alias as the fix, and when routing references a channel the device
+  cannot reach.
+
 ## [2.0.0] - 2025-10-19
 
 ### Overview

--- a/COMMIT-MESSSAGE-DRAFT
+++ b/COMMIT-MESSSAGE-DRAFT
@@ -1,0 +1,69 @@
+Fix microphone capture so multiple mics route reliably
+
+Live input was unusable on a multichannel interface and would produce a
+steady stream of overruns. Four separate defects, all in the path between
+the capture callback and the mixer:
+
+Frames were read from the capture ring buffer through a fixed 16-element
+array. On a device with more than 16 channels - the UMC1820 presents 18 or
+20 - only the first 16 samples of each frame were consumed. The remainder
+stayed in the buffer, so every subsequent read started mid-frame, the
+channel routing rotated continuously, and the leftover samples accumulated
+until the buffer was permanently full. Channels above 16 were also skipped
+outright by the routing, so the upper inputs could never be reached at all.
+Frames are now read in bulk into a preallocated scratch buffer with no
+channel ceiling.
+
+On the producer side, a full ring buffer was filled with `push_slice`,
+which writes as many samples as fit. When the space remaining was not a
+whole number of frames, that wrote a partial frame and permanently shifted
+the interleaving the mixer saw - one overrun and every microphone came out
+of the wrong speaker, silently and for good. Transfers are whole frames
+only now, so an overrun costs audio rather than correctness.
+
+Nothing bounded the backlog. A capture clock running faster than the
+output clock - normal whenever the microphone and the speakers are not on
+the same interface - filled the buffer and left it saturated, adding
+latency until it stuck at the buffer size. The mixer now discards whole
+frames once the backlog passes a ceiling.
+
+Both capture callbacks ran work that does not belong on a realtime thread:
+per-chunk Vec allocations in the resampler path, and a log write on every
+overrun. Stalling the capture thread costs whole capture periods, so the
+logging was helping cause the overruns it reported. The resampler now uses
+preallocated buffers with `process_into_buffer`, and losses are counted in
+atomics reported from an ordinary task every 10 seconds and through
+`GET /status/inputs`.
+
+Two things also stood in the way of routing arbitrary microphones. Capture
+streams were opened with cpal's default input config, whose heuristic
+prefers stereo at 44.1 kHz - so a 20-in interface opened as two channels
+and went through the resampler needlessly. The stream is now opened with
+the smallest channel count that covers every routed source channel, at the
+output sample rate when the device supports it, with `inputs[].channels`
+and `inputs[].sample_rate` available to override. And input devices were
+matched by exact name only, while output devices already fell back to ALSA
+card matching; that helper is now shared, so "hw:CARD=UMC1820, DEV=0"
+resolves for inputs too.
+
+Devices offering no f32 capture format, and routing that references a
+channel a device cannot reach, now fail at startup with an error naming
+the fix instead of a cryptic ALSA failure or silence.
+
+Verified by unit tests over the ring buffer transfer, the mixer read loop
+and the config selection, including the multi-microphone cases: several
+mics on one interface summed onto a shared endpoint, and mics on separate
+devices mixed with independent levels. Not verified against physical
+hardware - this machine has no sound device.
+
+Prompts:
+
+- I'm about to start using mqttaudio to route microphones to arbitrary
+  speaker endpoints, and I may need to route multiple microphones at once
+  all mixed together. Please verify this is possible and make any fixes
+  needed to make that path robust and reliable. A friend says he's getting
+  overflow errors. (Followed by a chat log covering device naming for the
+  UMC1820, the `input` config section being unreliable, and mic input
+  producing "a bunch of overflow errors".)
+
+Written by Claude.

--- a/COMMIT-MESSSAGE-DRAFT
+++ b/COMMIT-MESSSAGE-DRAFT
@@ -1,4 +1,4 @@
-Fix microphone capture so multiple mics route reliably
+Fix microphone capture, add fadeall, allow gains above unity
 
 Live input was unusable on a multichannel interface and would produce a
 steady stream of overruns. Four separate defects, all in the path between
@@ -50,11 +50,48 @@ Devices offering no f32 capture format, and routing that references a
 channel a device cannot reach, now fail at startup with an error naming
 the fix instead of a cryptic ALSA failure or silence.
 
-Verified by unit tests over the ring buffer transfer, the mixer read loop
-and the config selection, including the multi-microphone cases: several
-mics on one interface summed onto a shared endpoint, and mics on separate
-devices mixed with independent levels. Not verified against physical
-hardware - this machine has no sound device.
+Three things noticed alongside that work and asked for in the same change:
+
+A fadeall command, which did not exist - stopall had no fade-out
+counterpart, so bringing a room down gently meant one voice_fade_out per
+voice. It takes a time in milliseconds, defaults to one second when sent
+bare, and is reachable over MQTT and as POST /fadeall. Live inputs are
+untouched, matching what stopall stops.
+
+Gains above unity. Every volume control stopped at 1.0, so a quiet
+microphone or an underpowered subwoofer could only be attenuated, never
+lifted. The ceiling is now 4.0 (+12 dB) across inputs[].volume,
+audio.channel_volumes and the play, volume, voice_volume and input_volume
+commands. play was the odd one out in the other direction - its volume was
+passed through entirely unbounded - so it is clamped to the same limit now.
+The mixer already saturates its output, so a boost clips rather than
+wrapping.
+
+Raising that ceiling exposed that audio.channel_volumes did nothing at all:
+it was parsed and validated, and no code ever read it. Per-channel gain is
+now applied to the finished mix, after bass management, so boosting an LFE
+channel lifts the crossed-over bass with it. Its keys accept a channel
+number, an audio.channel_aliases name or an audio.channel_names label, and
+a key matching none of those is a validation error instead of being
+silently ignored.
+
+The channel naming error message. audio.channel_names maps number to name
+for display, audio.channel_aliases maps name to number and is what routing
+actually resolves against. Labelling a channel in the first and using that
+label in a route failed with a bare "Unknown channel alias", pointing at
+nothing. It now reads:
+
+  Unknown channel 'house_left': audio.channel_names labels channel 4 as
+  'house_left', but routing resolves against audio.channel_aliases - add
+  "house_left": 4 there
+
+Verified by unit tests over the ring buffer transfer, the mixer read loop,
+the config selection and the channel gain path, including the
+multi-microphone cases: several mics on one interface summed onto a shared
+endpoint, and mics on separate devices mixed with independent levels. The
+fadeall endpoint is tested through the real router and its emitted JSON fed
+back through the real parser, so the two halves are known to agree. Not
+verified against physical hardware - this machine has no sound device.
 
 Prompts:
 
@@ -65,5 +102,8 @@ Prompts:
   overflow errors. (Followed by a chat log covering device naming for the
   UMC1820, the `input` config section being unreliable, and mic input
   producing "a bunch of overflow errors".)
+- Address all the stuff from your last paragraph as part of this PR: add
+  fadeall, add the ability to have gains >1.0, and fix the error message to
+  clarify the distinction.
 
 Written by Claude.

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ curl -X POST http://localhost:8080/play \
 | [Voice Management](docs/features/voice-management.md) | Grouping and controlling sounds |
 | [Audio Ducking](docs/features/ducking.md)             | Automatic volume reduction      |
 | [Bass Management](docs/features/bass-management.md)   | LFE/subwoofer routing           |
-| [Microphone Input](docs/features/microphone-input.md) | Live audio input mixing         |
+| [Microphone Input](docs/features/microphone-input.md) | Live mic capture and routing    |
 | [Playback Control](docs/features/playback-control.md) | Seek, speed, reverse            |
 | [Caching](docs/features/caching.md)                   | HTTP caching and precaching     |
 

--- a/config.example.json
+++ b/config.example.json
@@ -32,8 +32,18 @@
       "6": "side_left",
       "7": "side_right"
     },
+    "channel_aliases": {
+      "front_left": 0,
+      "front_right": 1,
+      "center": 2,
+      "lfe": 3,
+      "rear_left": 4,
+      "rear_right": 5,
+      "side_left": 6,
+      "side_right": 7
+    },
     "channel_volumes": {
-      "lfe": 0.7,
+      "lfe": 1.4,
       "side_left": 0.85,
       "side_right": 0.85
     },
@@ -43,8 +53,12 @@
       "sample_rate: Output sample rate in Hz. Common values: 44100, 48000, 96000",
       "buffer_size: Audio buffer size in frames. Smaller = lower latency but higher CPU",
       "  Common values: 256 (low latency), 512 (balanced), 1024 (high compatibility)",
-      "channel_names: Optional mapping of channel numbers to human-readable names",
-      "channel_volumes: Per-channel calibration (0.0-1.0) to compensate for hardware differences"
+      "channel_names: Optional mapping of channel number to display name. Labels only",
+      "channel_aliases: Mapping of name to channel number. This is what routing resolves",
+      "  against - dest_channel, bass_management and play commands all use these names",
+      "channel_volumes: Per-channel output gain to compensate for hardware differences",
+      "  1.0 is unity, below attenuates, above boosts, up to 4.0 (+12 dB)",
+      "  Keys may be a channel number, a channel_aliases name, or a channel_names label"
     ]
   },
 

--- a/config.example.json
+++ b/config.example.json
@@ -85,6 +85,37 @@
     ]
   },
 
+  "inputs": [
+    {
+      "device": null,
+      "volume": 0.9,
+      "voice_id": "gm_mic",
+      "latency_ms": 25,
+      "channels": null,
+      "sample_rate": null,
+      "routes": [
+        { "source_channel": 0, "dest_channel": 4 },
+        { "source_channel": 1, "dest_channel": 4 },
+        { "source_channel": 2, "dest_channel": 5 }
+      ],
+
+      "_notes": [
+        "device: Input device name. null = system default. Use --list-inputs to see options",
+        "  Example: 'plughw:CARD=UMC1820,DEV=0'",
+        "  On Linux prefer the 'plughw:' alias of a card: capture is read as 32-bit float",
+        "  and plughw: converts from the card's native format",
+        "volume: Input volume (0.0-1.0)",
+        "voice_id: Voice name, used by input_volume/input_mute commands and ducking rules",
+        "latency_ms: Buffer latency (5-500). 20-30 is a good starting point for live mics",
+        "channels: Capture channels to open. null = smallest count covering every source_channel",
+        "sample_rate: Capture rate to request. null = match the output rate and skip resampling",
+        "routes: source_channel (mic input, 0-indexed) to dest_channel (speaker output)",
+        "  Two source channels sharing a dest_channel are summed there",
+        "  dest_channel may use a name from audio.channel_aliases"
+      ]
+    }
+  ],
+
   "_example_configs": {
     "_minimal": {
       "mqtt": {

--- a/docs/bugs.md
+++ b/docs/bugs.md
@@ -1,0 +1,60 @@
+# Known Bugs and Rough Edges
+
+Issues noticed while working on other things. Each entry says what is wrong and
+why it was left alone, so a later change can pick it up deliberately.
+
+## No `fadeall` command
+
+`stopall` exists; there is no fade-out equivalent. `voice_fade_out` can only
+fade one voice at a time, so bringing an entire room down gently means sending
+one command per voice.
+
+Reported by a user. Out of scope for the microphone routing work.
+
+## `channel_names` and `channel_aliases` are easy to confuse
+
+`audio.channel_names` maps index to name and is display-only.
+`audio.channel_aliases` maps name to index and is what routing actually
+resolves against. A config that names its channels in `channel_names` and then
+uses those names as a `dest_channel` fails validation with
+"Unknown channel alias", with nothing pointing at the real cause.
+
+Either the two should merge, or the validation error should say that the name
+exists in `channel_names` but not in `channel_aliases`.
+
+## Two input entries cannot share one capture device
+
+Each `inputs` entry opens its own capture stream. Two entries naming the same
+ALSA `hw:` device will not both open it, so several microphones on one
+interface must share a single entry, and therefore share one volume, one
+`voice_id` and one ducking behaviour.
+
+Supporting it means fanning one capture stream out to several `LiveInput`
+readers rather than the single-producer/single-consumer ring buffer used today.
+Documented as a limitation in `docs/features/microphone-input.md` instead.
+
+## Input volume cannot exceed 1.0
+
+`inputs[].volume` and the `input_volume` command both clamp to 1.0, so a quiet
+microphone cannot be boosted in software - only attenuated. The same limit
+applies to bass management gain, which a user has already asked about.
+
+## `input_mute` discards the configured volume
+
+Unmuting sets the volume to 1.0 rather than restoring what was configured, so
+a microphone set to 0.7 comes back at full level. There is already a code
+comment noting this in `src/main.rs`.
+
+## The audio callback locks a std Mutex
+
+`mix_audio` runs under `mixer_state.lock()`, which the HTTP handlers, the
+command loop and the input health monitor also take. A non-realtime thread
+holding that lock while the audio thread waits on it is a priority inversion
+that shows up as an output glitch. It has not caused a reported problem, but it
+is the reason to keep every other lock holder short.
+
+## `mqtt::client::tests::test_mqtt_event_processing` needs a live broker
+
+The test publishes to `localhost:1883` and fails without a broker running. It
+is a real integration test, not a broken one, but it makes `cargo test` fail on
+a machine that has no MQTT server.

--- a/docs/bugs.md
+++ b/docs/bugs.md
@@ -3,25 +3,6 @@
 Issues noticed while working on other things. Each entry says what is wrong and
 why it was left alone, so a later change can pick it up deliberately.
 
-## No `fadeall` command
-
-`stopall` exists; there is no fade-out equivalent. `voice_fade_out` can only
-fade one voice at a time, so bringing an entire room down gently means sending
-one command per voice.
-
-Reported by a user. Out of scope for the microphone routing work.
-
-## `channel_names` and `channel_aliases` are easy to confuse
-
-`audio.channel_names` maps index to name and is display-only.
-`audio.channel_aliases` maps name to index and is what routing actually
-resolves against. A config that names its channels in `channel_names` and then
-uses those names as a `dest_channel` fails validation with
-"Unknown channel alias", with nothing pointing at the real cause.
-
-Either the two should merge, or the validation error should say that the name
-exists in `channel_names` but not in `channel_aliases`.
-
 ## Two input entries cannot share one capture device
 
 Each `inputs` entry opens its own capture stream. Two entries naming the same
@@ -33,17 +14,17 @@ Supporting it means fanning one capture stream out to several `LiveInput`
 readers rather than the single-producer/single-consumer ring buffer used today.
 Documented as a limitation in `docs/features/microphone-input.md` instead.
 
-## Input volume cannot exceed 1.0
-
-`inputs[].volume` and the `input_volume` command both clamp to 1.0, so a quiet
-microphone cannot be boosted in software - only attenuated. The same limit
-applies to bass management gain, which a user has already asked about.
-
 ## `input_mute` discards the configured volume
 
 Unmuting sets the volume to 1.0 rather than restoring what was configured, so
-a microphone set to 0.7 comes back at full level. There is already a code
-comment noting this in `src/main.rs`.
+a microphone set to 0.7 comes back at full level, and one boosted to 2.0 comes
+back quieter. There is already a code comment noting this in `src/main.rs`.
+
+## `fadeall` does not fade live inputs
+
+`fadeall` fades the playing samples, matching what `stopall` stops. A live
+microphone keeps running through it, which is usually what you want but is
+worth knowing. `input_mute` is the per-microphone control.
 
 ## The audio callback locks a std Mutex
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -42,12 +42,16 @@ Play an audio file.
 | `file` | string | *required* | File path or HTTP/HTTPS URL |
 | `id` | string | auto | Unique ID for targeting this sound later |
 | `voice` | string | auto | Voice group name |
-| `volume` | float | 1.0 | Volume (0.0 to 1.0) |
+| `volume` | float | 1.0 | Volume (0.0 to 4.0, unity is 1.0) |
 | `loop` | boolean | false | Loop playback continuously |
 | `crossfade_ms` | integer | 0 | Crossfade duration at loop boundaries (0 = disabled) |
 | `fade_in` | integer | 0 | Fade-in duration (milliseconds) |
 | `start_position_ms` | integer | 0 | Start position (milliseconds) |
 | `channel_map` | array | auto | Channel routing (see below) |
+
+Volumes are gains: 1.0 is unity, below that attenuates and above that boosts, up
+to 4.0 (+12 dB). The mixer saturates its output, so a boost loud enough to
+exceed full scale clips rather than wrapping around.
 
 **Channel Mapping:**
 
@@ -98,6 +102,28 @@ Stop all playing audio immediately.
 ```json
 {"command": "stopall"}
 ```
+
+### fadeall
+
+Fade all playing audio out, then stop it. Samples are removed once their fade
+completes.
+
+```json
+{"command": "fadeall", "time": 2000}
+```
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `time` | integer | `1000` | Fade duration in milliseconds. Also accepted as `fade_out_ms` |
+
+Sent without a `time`, it fades everything over one second:
+
+```json
+{"command": "fadeall"}
+```
+
+Live inputs are not affected, the same as with `stopall`. Use `input_mute` for
+a microphone.
 
 ---
 
@@ -187,7 +213,7 @@ Adjust volume of specific samples.
 | `id` | string | — | Target sample ID |
 | `file` | string | — | Target samples playing this file |
 | `voice` | string | — | Target samples in this voice |
-| `volume` | float | *required* | New volume (0.0 to 1.0) |
+| `volume` | float | *required* | New volume (0.0 to 4.0, unity is 1.0) |
 
 ---
 
@@ -236,7 +262,7 @@ Adjust volume for all samples in a voice.
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `voice` | string | *required* | Voice name |
-| `volume` | float | *required* | New volume (0.0 to 1.0) |
+| `volume` | float | *required* | New volume (0.0 to 4.0, unity is 1.0) |
 
 ---
 
@@ -293,7 +319,7 @@ Adjust volume for a microphone/input device.
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `input` | string | *required* | Input name (voice_id) or index |
-| `volume` | float | *required* | Volume (0.0 to 1.0) |
+| `volume` | float | *required* | Volume (0.0 to 4.0, unity is 1.0) |
 
 ### input_mute
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -165,6 +165,8 @@ Audio output settings.
 | `buffer_size` | integer | `512` | Buffer size in frames (lower = less latency, more CPU) |
 | `channels` | integer | auto-detect | Number of output channels |
 | `channel_aliases` | object | `{}` | Named aliases for channel numbers |
+| `channel_names` | object | `{}` | Display labels for channel numbers |
+| `channel_volumes` | object | `{}` | Per-channel output gain |
 
 #### Channel Aliases
 
@@ -194,6 +196,56 @@ The `channel_aliases` field lets you define meaningful names for channel numbers
 ```
 
 This makes configurations more readable and less error-prone. Channel aliases can also be used in MQTT play commands (see [Commands](commands.md)).
+
+#### Channel Names vs Channel Aliases
+
+Two fields name channels and they are not interchangeable:
+
+| Field | Direction | Used for |
+|-------|-----------|----------|
+| `channel_aliases` | name → number | Resolving channels in routes, bass management and play commands |
+| `channel_names` | number → name | Labelling channels for display |
+
+```json
+"audio": {
+  "channel_aliases": { "booth": 6 },
+  "channel_names": { "6": "booth" }
+}
+```
+
+Routing resolves against `channel_aliases` only. A name defined in
+`channel_names` and then used as a `dest_channel` fails validation with the
+entry you need to add:
+
+```
+inputs[0].routes[0].dest_channel: Unknown channel 'booth': audio.channel_names
+labels channel 6 as 'booth', but routing resolves against audio.channel_aliases
+- add "booth": 6 there
+```
+
+#### Channel Volumes
+
+`channel_volumes` sets a per-channel output gain, applied to the finished mix.
+Use it to level speakers against each other, or to lift an underpowered
+subwoofer:
+
+```json
+"audio": {
+  "channel_aliases": { "lfe": 3, "surround_left": 4 },
+  "channel_volumes": {
+    "lfe": 1.6,
+    "surround_left": 0.85,
+    "7": 0.9
+  }
+}
+```
+
+Keys may be a channel number, a `channel_aliases` name, or a `channel_names`
+label. Unity is 1.0, the maximum is 4.0 (+12 dB), and entries beyond the
+device's channel count are ignored. Gain is applied after bass management, so
+boosting the LFE channel raises the crossed-over bass along with anything
+routed there directly. The mixer saturates its output, so an over-enthusiastic
+boost clips rather than wrapping.
 
 ### cache
 
@@ -298,7 +350,7 @@ Microphone/input device configuration.
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `device` | string | *required* | Input device name (use `--list-inputs`) |
-| `volume` | float | `1.0` | Input volume (0.0 to 1.0) |
+| `volume` | float | `1.0` | Input volume (0.0 to 4.0, unity is 1.0) |
 | `voice_id` | string | — | Voice name for ducking integration |
 | `routes` | array | *required* | Channel routing (source → dest, can use aliases) |
 | `latency_ms` | integer | `25` | Buffer latency (5-500ms) |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -302,6 +302,8 @@ Microphone/input device configuration.
 | `voice_id` | string | — | Voice name for ducking integration |
 | `routes` | array | *required* | Channel routing (source → dest, can use aliases) |
 | `latency_ms` | integer | `25` | Buffer latency (5-500ms) |
+| `channels` | integer | *auto* | Capture channels to open (1-64). Defaults to the smallest count that covers every `source_channel` |
+| `sample_rate` | integer | *auto* | Capture rate to request (8000-192000). Defaults to the output rate, which avoids resampling |
 
 The `dest_channel` in routes can use channel aliases defined in `audio.channel_aliases`.
 

--- a/docs/features/microphone-input.md
+++ b/docs/features/microphone-input.md
@@ -33,7 +33,7 @@ Add inputs to your config file:
 | Field | Description |
 |-------|-------------|
 | `device` | Input device name (use `--list-inputs` to see options) |
-| `volume` | Input volume (0.0 to 1.0) |
+| `volume` | Input volume (0.0 to 4.0, unity is 1.0) |
 | `voice_id` | Voice name for ducking integration |
 | `routes` | Channel routing (source → destination) |
 | `latency_ms` | Buffer latency (5-500ms) |
@@ -49,6 +49,13 @@ to reach it, while a single-mic route stays narrow.
 
 Set it explicitly when a device misreports its capabilities, or when you want a
 fixed layout regardless of routing.
+
+### Volume
+
+`volume` is a gain: 1.0 passes the microphone through untouched, below that
+attenuates and above that boosts, up to 4.0 (+12 dB). Boosting is how you lift
+a quiet lavalier or a preamp that will not go loud enough; the mixer saturates
+its output, so too much gain clips rather than wrapping.
 
 ### Sample rate
 
@@ -345,6 +352,11 @@ A handful of `underrun_frames` at startup is normal while the buffer primes.
 - Check routes are configured correctly
 - Check volume is not 0
 - Check the device isn't muted via `input_mute`
+
+**Microphone is too quiet:**
+- Raise `volume` above 1.0, or send `input_volume` with a value above 1.0
+- Check `underrun_frames` is not climbing, which sounds like dropouts rather
+  than low level
 
 **Startup fails with "device offers no f32 capture format":**
 - Use the `plughw:` alias of the same card instead of `hw:`

--- a/docs/features/microphone-input.md
+++ b/docs/features/microphone-input.md
@@ -37,6 +37,24 @@ Add inputs to your config file:
 | `voice_id` | Voice name for ducking integration |
 | `routes` | Channel routing (source → destination) |
 | `latency_ms` | Buffer latency (5-500ms) |
+| `channels` | Capture channels to open. Omit to let the routes decide |
+| `sample_rate` | Capture rate to request. Omit to match the output rate |
+
+### Channel count
+
+`channels` is normally left out. The stream is opened with the smallest count
+the device supports that still covers every `source_channel` in `routes`, so
+routing `source_channel: 8` on an 18-in interface opens all the channels needed
+to reach it, while a single-mic route stays narrow.
+
+Set it explicitly when a device misreports its capabilities, or when you want a
+fixed layout regardless of routing.
+
+### Sample rate
+
+`sample_rate` is normally left out. The capture stream is opened at the output
+rate whenever the device supports it, which keeps the resampler out of the
+signal path entirely.
 
 ## Finding Input Devices
 
@@ -56,6 +74,22 @@ Available audio input devices:
      Sample rate: 44100 Hz
      Channels: 2
 ```
+
+### ALSA Device Names
+
+On Linux, prefer the `plughw:` alias of a card over `hw:`:
+
+```json
+"device": "plughw:CARD=UMC1820,DEV=0"
+```
+
+Capture is read as 32-bit float. `plughw:` converts from the card's native
+format; a bare `hw:` device that only offers integer formats is rejected at
+startup with the format it does offer. `hw:` works where the card exposes a
+float format natively.
+
+Names are matched exactly first, then by ALSA card, so `"hw:CARD=UMC1820, DEV=0"`
+and `"hw:1,0"` both resolve to the same enumerated device.
 
 ## Routing
 
@@ -93,6 +127,58 @@ Route a microphone to all player earpiece channels:
   {"source_channel": 0, "dest_channel": 7}
 ]
 ```
+
+### Several Microphones on One Interface
+
+A multichannel interface exposes each of its microphone preamps as a source
+channel, so one `inputs` entry can carry several microphones at once. Routing
+two source channels to the same destination sums them:
+
+```json
+{
+  "device": "plughw:CARD=UMC1820,DEV=0",
+  "voice_id": "room_mics",
+  "routes": [
+    {"source_channel": 0, "dest_channel": 4},
+    {"source_channel": 1, "dest_channel": 4},
+    {"source_channel": 2, "dest_channel": 5}
+  ]
+}
+```
+
+Microphones 1 and 2 are mixed together onto output 4; microphone 3 goes to
+output 5 on its own. There is no limit on how many source channels an interface
+can contribute.
+
+### Several Microphones with Independent Control
+
+Everything in one `inputs` entry shares a volume, a `voice_id` and therefore
+one ducking behaviour. For per-microphone control, give each microphone its own
+entry:
+
+```json
+"inputs": [
+  {
+    "device": "Gamemaster Headset",
+    "voice_id": "gm_mic",
+    "volume": 0.9,
+    "routes": [{"source_channel": 0, "dest_channel": 4}]
+  },
+  {
+    "device": "Handheld Mic",
+    "voice_id": "handheld",
+    "volume": 0.7,
+    "routes": [{"source_channel": 0, "dest_channel": 4}]
+  }
+]
+```
+
+Both feed output 4 and are summed there, but each can be levelled, muted and
+ducked on its own.
+
+Separate entries need separate devices. Two entries naming the same ALSA `hw:`
+device will not both open it; route the extra microphones as extra source
+channels of a single entry instead.
 
 ## MQTT Commands
 
@@ -211,6 +297,47 @@ WARN Input device 'USB Microphone' sample rate (44100 Hz) differs from output (4
 
 For lowest latency, use an input device that matches your output sample rate.
 
+## Monitoring Input Health
+
+Capture problems are counted per input and reported two ways.
+
+Every 10 seconds, any input that lost or starved audio logs a warning:
+
+```
+WARN Input 0 ('gm_mic'): 480 frames overran, 0 trimmed, 0 starved in 10s (backlog 960 frames)
+```
+
+`GET /status/inputs` reports the same counters as running totals:
+
+```json
+{
+  "inputs": [
+    {
+      "index": 0,
+      "voice_id": "gm_mic",
+      "volume": 0.9,
+      "channels": 2,
+      "muted": false,
+      "backlog_frames": 480,
+      "max_backlog_frames": 1920,
+      "dropped_frames": 0,
+      "trimmed_frames": 0,
+      "underrun_frames": 0
+    }
+  ]
+}
+```
+
+| Counter | Meaning |
+|---------|---------|
+| `backlog_frames` | Captured audio waiting to be mixed. Its steady-state value is your actual input latency |
+| `max_backlog_frames` | Ceiling before the backlog is trimmed |
+| `dropped_frames` | Capture could not hand audio over because the buffer was full |
+| `trimmed_frames` | Backlog discarded to keep latency bounded |
+| `underrun_frames` | Output frames with no captured audio available |
+
+A handful of `underrun_frames` at startup is normal while the buffer primes.
+
 ## Troubleshooting
 
 **No audio from microphone:**
@@ -219,9 +346,29 @@ For lowest latency, use an input device that matches your output sample rate.
 - Check volume is not 0
 - Check the device isn't muted via `input_mute`
 
+**Startup fails with "device offers no f32 capture format":**
+- Use the `plughw:` alias of the same card instead of `hw:`
+
+**Startup fails with "routing needs N capture channels":**
+- The device cannot be opened wide enough to reach a `source_channel` in your
+  routes. Check the channel count from `--list-inputs`, and remember source
+  channels are 0-indexed: input 1 on the front panel is `source_channel: 0`
+
+**Overruns (`dropped_frames` climbing):**
+- The capture thread is producing faster than the mixer consumes. Raise
+  `latency_ms` to give the buffer more headroom
+- Check CPU usage - a stalled audio callback shows up here first
+
+**Trims (`trimmed_frames` climbing steadily):**
+- Input and output clocks are drifting apart, which happens when the microphone
+  and the speakers are on different devices. Trimming keeps latency bounded, at
+  the cost of an occasional discontinuity. Putting capture and playback on the
+  same interface removes the drift
+
 **Audio is delayed:**
 - Reduce `latency_ms`
 - Use a device with matching sample rate
+- Check `backlog_frames` - a steadily large backlog is added latency
 
 **Audio glitches:**
 - Increase `latency_ms`

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -54,6 +54,7 @@ Config file example:
 | `/status/samples` | GET | List of active samples |
 | `/status/voices` | GET | List of active voices |
 | `/status/cache` | GET | Cache statistics |
+| `/status/inputs` | GET | Live inputs and their capture health |
 
 ### Command Endpoints (Authentication Required if configured)
 
@@ -63,6 +64,7 @@ Config file example:
 | `/play` | POST | Play audio file |
 | `/stop` | POST | Stop samples by selector |
 | `/stopall` | POST | Stop all playback |
+| `/fadeall` | POST | Fade out all playback |
 | `/volume` | POST | Set sample volume |
 | `/seek` | POST | Seek to position |
 | `/speed` | POST | Change playback speed |
@@ -161,6 +163,11 @@ curl -X POST http://localhost:8080/play \
 
 # Stop all playback
 curl -X POST http://localhost:8080/stopall
+
+# Fade all playback out over 2 seconds
+curl -X POST http://localhost:8080/fadeall \
+  -H "Content-Type: application/json" \
+  -d '{"time": 2000}'
 
 # Get status
 curl http://localhost:8080/status

--- a/src/audio/device.rs
+++ b/src/audio/device.rs
@@ -297,6 +297,108 @@ pub fn format_device_list(list: &DeviceList) -> String {
     output
 }
 
+/// Try to match two ALSA device names
+/// Returns Some(true) if they match, Some(false) if same prefix but different card, None if not comparable
+#[cfg(target_os = "linux")]
+pub fn try_match_alsa_device(requested: &str, enumerated: &str) -> Option<bool> {
+    // Get prefix (hw:, plughw:, sysdefault:, etc.)
+    let prefixes = ["plughw:", "hw:", "sysdefault:", "dmix:", "front:", "surround"];
+
+    for prefix in prefixes {
+        if requested.starts_with(prefix) && enumerated.starts_with(prefix) {
+            // Both have the same prefix, compare by card number
+            let req_card = extract_alsa_card_from_name(requested);
+            let enum_card = extract_alsa_card_from_name(enumerated);
+
+            match (req_card, enum_card) {
+                (Some(r), Some(e)) => return Some(r == e),
+                _ => continue,
+            }
+        }
+    }
+
+    None
+}
+
+/// Extract card identifier from ALSA device name
+/// Handles both numeric (hw:1,0) and named (hw:CARD=UMC1820,DEV=0) formats
+#[cfg(target_os = "linux")]
+fn extract_alsa_card_from_name(name: &str) -> Option<AlsaCardId> {
+    // Find prefix end
+    let prefixes = ["plughw:", "hw:", "sysdefault:", "dmix:", "front:", "surround"];
+
+    for prefix in prefixes {
+        if name.starts_with(prefix) {
+            let rest = &name[prefix.len()..];
+
+            // Try "CARD=name" format first
+            if rest.starts_with("CARD=") {
+                let card_part = &rest[5..];
+                let card_name = if let Some(comma_pos) = card_part.find(',') {
+                    &card_part[..comma_pos]
+                } else {
+                    card_part
+                };
+                return Some(AlsaCardId::Name(card_name.to_string()));
+            }
+
+            // Try numeric format "N,M" or just "N"
+            let num_part = if let Some(comma_pos) = rest.find(',') {
+                &rest[..comma_pos]
+            } else {
+                rest
+            };
+
+            if let Ok(num) = num_part.parse::<u32>() {
+                return Some(AlsaCardId::Index(num));
+            }
+        }
+    }
+
+    None
+}
+
+/// ALSA card identifier - can be either index or name
+#[cfg(target_os = "linux")]
+#[derive(Debug)]
+enum AlsaCardId {
+    Index(u32),
+    Name(String),
+}
+
+#[cfg(target_os = "linux")]
+impl PartialEq for AlsaCardId {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (AlsaCardId::Index(a), AlsaCardId::Index(b)) => a == b,
+            (AlsaCardId::Name(a), AlsaCardId::Name(b)) => a == b,
+            // Cross-compare by looking up card index from name
+            (AlsaCardId::Index(idx), AlsaCardId::Name(name)) |
+            (AlsaCardId::Name(name), AlsaCardId::Index(idx)) => {
+                // Try to match card name to index by checking /proc/asound/cards
+                if let Ok(cards) = std::fs::read_to_string("/proc/asound/cards") {
+                    for line in cards.lines() {
+                        // Format: " 1 [UMC1820        ]: USB-Audio - UMC1820"
+                        if let Some(bracket_start) = line.find('[') {
+                            if let Some(bracket_end) = line.find(']') {
+                                let card_id = line[bracket_start + 1..bracket_end].trim();
+                                if card_id == name {
+                                    // Found the card name, extract index
+                                    let idx_str = line[..bracket_start].trim();
+                                    if let Ok(card_idx) = idx_str.parse::<u32>() {
+                                        return card_idx == *idx;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                false
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/audio/engine.rs
+++ b/src/audio/engine.rs
@@ -138,7 +138,7 @@ pub fn find_output_device(name: Option<&str>) -> Result<cpal::Device, Box<dyn st
                         if let Ok(n) = device.name() {
                             // Try matching ALSA device names by card number
                             // Supports hw:, plughw:, sysdefault:
-                            if let Some(matched) = try_match_alsa_device(device_name, &n) {
+                            if let Some(matched) = super::device::try_match_alsa_device(device_name, &n) {
                                 if matched {
                                     tracing::info!("Matched ALSA device '{}' to '{}'", device_name, n);
                                     return Ok(device);
@@ -154,108 +154,6 @@ pub fn find_output_device(name: Option<&str>) -> Result<cpal::Device, Box<dyn st
         None => {
             host.default_output_device()
                 .ok_or_else(|| "No default output device available".into())
-        }
-    }
-}
-
-/// Try to match two ALSA device names
-/// Returns Some(true) if they match, Some(false) if same prefix but different card, None if not comparable
-#[cfg(target_os = "linux")]
-fn try_match_alsa_device(requested: &str, enumerated: &str) -> Option<bool> {
-    // Get prefix (hw:, plughw:, sysdefault:, etc.)
-    let prefixes = ["plughw:", "hw:", "sysdefault:", "dmix:", "front:", "surround"];
-
-    for prefix in prefixes {
-        if requested.starts_with(prefix) && enumerated.starts_with(prefix) {
-            // Both have the same prefix, compare by card number
-            let req_card = extract_alsa_card_from_name(requested);
-            let enum_card = extract_alsa_card_from_name(enumerated);
-
-            match (req_card, enum_card) {
-                (Some(r), Some(e)) => return Some(r == e),
-                _ => continue,
-            }
-        }
-    }
-
-    None
-}
-
-/// Extract card identifier from ALSA device name
-/// Handles both numeric (hw:1,0) and named (hw:CARD=UMC1820,DEV=0) formats
-#[cfg(target_os = "linux")]
-fn extract_alsa_card_from_name(name: &str) -> Option<AlsaCardId> {
-    // Find prefix end
-    let prefixes = ["plughw:", "hw:", "sysdefault:", "dmix:", "front:", "surround"];
-
-    for prefix in prefixes {
-        if name.starts_with(prefix) {
-            let rest = &name[prefix.len()..];
-
-            // Try "CARD=name" format first
-            if rest.starts_with("CARD=") {
-                let card_part = &rest[5..];
-                let card_name = if let Some(comma_pos) = card_part.find(',') {
-                    &card_part[..comma_pos]
-                } else {
-                    card_part
-                };
-                return Some(AlsaCardId::Name(card_name.to_string()));
-            }
-
-            // Try numeric format "N,M" or just "N"
-            let num_part = if let Some(comma_pos) = rest.find(',') {
-                &rest[..comma_pos]
-            } else {
-                rest
-            };
-
-            if let Ok(num) = num_part.parse::<u32>() {
-                return Some(AlsaCardId::Index(num));
-            }
-        }
-    }
-
-    None
-}
-
-/// ALSA card identifier - can be either index or name
-#[cfg(target_os = "linux")]
-#[derive(Debug)]
-enum AlsaCardId {
-    Index(u32),
-    Name(String),
-}
-
-#[cfg(target_os = "linux")]
-impl PartialEq for AlsaCardId {
-    fn eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            (AlsaCardId::Index(a), AlsaCardId::Index(b)) => a == b,
-            (AlsaCardId::Name(a), AlsaCardId::Name(b)) => a == b,
-            // Cross-compare by looking up card index from name
-            (AlsaCardId::Index(idx), AlsaCardId::Name(name)) |
-            (AlsaCardId::Name(name), AlsaCardId::Index(idx)) => {
-                // Try to match card name to index by checking /proc/asound/cards
-                if let Ok(cards) = std::fs::read_to_string("/proc/asound/cards") {
-                    for line in cards.lines() {
-                        // Format: " 1 [UMC1820        ]: USB-Audio - UMC1820"
-                        if let Some(bracket_start) = line.find('[') {
-                            if let Some(bracket_end) = line.find(']') {
-                                let card_id = line[bracket_start + 1..bracket_end].trim();
-                                if card_id == name {
-                                    // Found the card name, extract index
-                                    let idx_str = line[..bracket_start].trim();
-                                    if let Ok(card_idx) = idx_str.parse::<u32>() {
-                                        return card_idx == *idx;
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-                false
-            }
         }
     }
 }

--- a/src/audio/engine.rs
+++ b/src/audio/engine.rs
@@ -465,6 +465,7 @@ pub fn test_mixer() -> Result<Stream, Box<dyn std::error::Error>> {
         active_samples,
         live_inputs: Vec::new(),
         output_channels,
+        channel_gains: vec![1.0; output_channels],
         ducking_engine: None,
         bass_management: None,
     }));

--- a/src/audio/input.rs
+++ b/src/audio/input.rs
@@ -2,8 +2,17 @@
 // ABOUTME: Manages input streams and routes audio to mixer via ring buffers.
 
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
-use cpal::{Device, Stream, SupportedStreamConfig};
+use cpal::{Device, SampleFormat, SampleRate, Stream, SupportedStreamConfig};
 use ringbuf::{HeapRb, HeapConsumer, HeapProducer};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+/// ALSA plugin devices advertise absurd rates (4294967295 Hz); anything above
+/// this is treated as a bogus capability report.
+const MAX_REASONABLE_SAMPLE_RATE: u32 = 384000;
+
+/// Upper bound on channel counts accepted from device capability reports
+const MAX_REASONABLE_CHANNELS: u16 = 64;
 
 /// List available audio input devices
 pub fn list_input_devices() {
@@ -20,10 +29,6 @@ pub fn list_input_devices() {
                     if let Ok(configs) = device.supported_input_configs() {
                         let mut max_channels = 0u16;
                         let mut sample_rates: Vec<(u32, u32)> = Vec::new();
-
-                        // Filter configs: ignore those with absurd sample rates
-                        // (ALSA plugins report 4294967295 Hz which is clearly fake)
-                        const MAX_REASONABLE_SAMPLE_RATE: u32 = 384000;
 
                         for config in configs {
                             let max_rate = config.max_sample_rate().0;
@@ -73,21 +78,41 @@ pub fn list_input_devices() {
 }
 
 /// Get an input device by name, or the default if name is None
+///
+/// Falls back to ALSA card matching so that names written by hand
+/// ("hw:CARD=UMC1820, DEV=0") still resolve to the enumerated device, the same
+/// way output devices are resolved.
 pub fn get_input_device(name: Option<&str>) -> Result<Device, InputError> {
     let host = cpal::default_host();
 
     match name {
         Some(device_name) => {
-            let devices = host.input_devices()
-                .map_err(|e| InputError::DeviceEnumeration(e.to_string()))?;
+            let devices: Vec<Device> = host.input_devices()
+                .map_err(|e| InputError::DeviceEnumeration(e.to_string()))?
+                .collect();
 
-            for device in devices {
+            for device in &devices {
                 if let Ok(n) = device.name() {
                     if n == device_name {
-                        return Ok(device);
+                        return Ok(device.clone());
                     }
                 }
             }
+
+            #[cfg(target_os = "linux")]
+            {
+                for device in &devices {
+                    if let Ok(n) = device.name() {
+                        if crate::audio::device::try_match_alsa_device(device_name, &n)
+                            == Some(true)
+                        {
+                            tracing::info!("Matched ALSA input device '{}' to '{}'", device_name, n);
+                            return Ok(device.clone());
+                        }
+                    }
+                }
+            }
+
             Err(InputError::DeviceNotFound(device_name.to_string()))
         }
         None => {
@@ -95,6 +120,146 @@ pub fn get_input_device(name: Option<&str>) -> Result<Device, InputError> {
                 .ok_or_else(|| InputError::NoDefaultDevice)
         }
     }
+}
+
+/// Lowest input channel count that can serve every routed source channel
+pub fn required_channels(channel_map: &[(usize, usize)]) -> usize {
+    channel_map.iter().map(|(src, _)| src + 1).max().unwrap_or(0)
+}
+
+/// Choose the channel count to open a capture stream with.
+///
+/// `exact` forces a specific count, for hardware whose capabilities cpal
+/// reports incorrectly. Otherwise the smallest supported count that covers
+/// every routed source channel is used, so a device offering a range is not
+/// opened wider than the routing needs while a device with a fixed layout
+/// (ALSA `hw:` on a multichannel interface) still matches. Returns None when
+/// no supported count satisfies the request.
+pub fn select_channel_count(available: &[u16], exact: Option<usize>, minimum: usize) -> Option<u16> {
+    match exact {
+        Some(requested) => available
+            .iter()
+            .copied()
+            .find(|&ch| ch as usize == requested),
+        None => available
+            .iter()
+            .copied()
+            .filter(|&ch| ch as usize >= minimum.max(1))
+            .min(),
+    }
+}
+
+/// Find a capture configuration for the device.
+///
+/// Only f32 configurations are considered: the capture callback reads f32
+/// samples, and ALSA `hw:` devices that expose integer formats only must be
+/// opened through their `plughw:` alias instead.
+pub fn find_input_config(
+    device: &Device,
+    requested_channels: Option<usize>,
+    minimum_channels: usize,
+    preferred_sample_rate: u32,
+) -> Result<SupportedStreamConfig, InputError> {
+    let supported: Vec<_> = device
+        .supported_input_configs()
+        .map_err(|e| InputError::ConfigError(e.to_string()))?
+        .filter(|c| c.max_sample_rate().0 <= MAX_REASONABLE_SAMPLE_RATE)
+        .filter(|c| c.channels() <= MAX_REASONABLE_CHANNELS)
+        .collect();
+
+    // Plugin devices often enumerate nothing usable; fall back to whatever the
+    // device reports as its default and let the stream build succeed or fail.
+    if supported.is_empty() {
+        return get_input_config(device);
+    }
+
+    let float_configs: Vec<_> = supported
+        .iter()
+        .filter(|c| c.sample_format() == SampleFormat::F32)
+        .collect();
+
+    if float_configs.is_empty() {
+        let formats: Vec<String> = supported
+            .iter()
+            .map(|c| format!("{:?}", c.sample_format()))
+            .collect::<std::collections::BTreeSet<_>>()
+            .into_iter()
+            .collect();
+        return Err(InputError::ConfigError(format!(
+            "device offers no f32 capture format (has: {}); use the 'plughw:' alias for this card",
+            formats.join(", ")
+        )));
+    }
+
+    let available: Vec<u16> = float_configs.iter().map(|c| c.channels()).collect();
+    let channels = select_channel_count(&available, requested_channels, minimum_channels)
+        .ok_or_else(|| {
+            let mut counts: Vec<u16> = available.clone();
+            counts.sort_unstable();
+            counts.dedup();
+            match requested_channels {
+                Some(ch) => InputError::ConfigError(format!(
+                    "device does not support {} capture channels (supports: {:?})",
+                    ch, counts
+                )),
+                None => InputError::ConfigError(format!(
+                    "routing needs {} capture channels but device supports at most {:?}",
+                    minimum_channels, counts
+                )),
+            }
+        })?;
+
+    let matching: Vec<_> = float_configs
+        .iter()
+        .filter(|c| c.channels() == channels)
+        .collect();
+
+    // Matching the output rate keeps the resampler out of the signal path
+    let exact_rate = matching.iter().find(|c| {
+        c.min_sample_rate().0 <= preferred_sample_rate
+            && preferred_sample_rate <= c.max_sample_rate().0
+    });
+
+    match exact_rate {
+        Some(c) => Ok(c.with_sample_rate(SampleRate(preferred_sample_rate))),
+        None => {
+            let closest = matching[0];
+            let rate = preferred_sample_rate
+                .max(closest.min_sample_rate().0)
+                .min(closest.max_sample_rate().0);
+            Ok(closest.with_sample_rate(SampleRate(rate)))
+        }
+    }
+}
+
+/// Push whole frames into the ring buffer, returning the number of frames written.
+///
+/// A partially written frame would permanently shift the channel interleaving
+/// seen by the mixer, sending each microphone to the wrong output and leaving a
+/// residue that grows until the buffer is full. Frames that do not fit are
+/// counted as dropped instead.
+fn push_frames(
+    producer: &mut HeapProducer<f32>,
+    data: &[f32],
+    channels: usize,
+    dropped_frames: &AtomicU64,
+) -> usize {
+    if channels == 0 {
+        return 0;
+    }
+
+    let frames_in = data.len() / channels;
+    let frames_free = producer.free_len() / channels;
+    let frames_out = frames_in.min(frames_free);
+
+    if frames_out > 0 {
+        producer.push_slice(&data[..frames_out * channels]);
+    }
+    if frames_out < frames_in {
+        dropped_frames.fetch_add((frames_in - frames_out) as u64, Ordering::Relaxed);
+    }
+
+    frames_out
 }
 
 /// Get the default input configuration for a device
@@ -121,6 +286,12 @@ pub fn create_ring_buffer(size: usize) -> (HeapProducer<f32>, HeapConsumer<f32>)
 pub struct InputStreamConfig {
     pub device_name: Option<String>,
     pub latency_ms: u32,
+    /// Exact channel count to open (None = smallest count covering `min_channels`)
+    pub channels: Option<usize>,
+    /// Lowest channel count the configured routing needs
+    pub min_channels: usize,
+    /// Capture rate to request (None = match the output rate when supported)
+    pub sample_rate: Option<u32>,
 }
 
 impl Default for InputStreamConfig {
@@ -128,6 +299,9 @@ impl Default for InputStreamConfig {
         Self {
             device_name: None,
             latency_ms: 20, // 20ms default latency buffer
+            channels: None,
+            min_channels: 1,
+            sample_rate: None,
         }
     }
 }
@@ -138,6 +312,10 @@ pub struct ActiveInput {
     stream: Stream,
     consumer: Option<HeapConsumer<f32>>,
     pub channels: usize,
+    pub sample_rate: u32,
+    /// Frames the capture callback could not hand over because the ring buffer
+    /// was full. Shared with the mixer so input health can be reported.
+    pub dropped_frames: Arc<AtomicU64>,
 }
 
 impl ActiveInput {
@@ -156,14 +334,36 @@ pub fn create_input_stream(
 ) -> Result<ActiveInput, InputError> {
     let device = get_input_device(config.device_name.as_deref())?;
     let device_name = device.name().unwrap_or_else(|_| "Unknown".to_string());
-    let supported_config = get_input_config(&device)?;
+
+    let preferred_rate = config.sample_rate.unwrap_or(target_sample_rate);
+    let supported_config = find_input_config(
+        &device,
+        config.channels,
+        config.min_channels,
+        preferred_rate,
+    )?;
 
     let input_sample_rate = supported_config.sample_rate().0;
     let channels = supported_config.channels() as usize;
 
+    if channels == 0 {
+        return Err(InputError::ConfigError(format!(
+            "device '{}' reported zero capture channels",
+            device_name
+        )));
+    }
+
+    if channels < config.min_channels {
+        return Err(InputError::ConfigError(format!(
+            "routing needs {} capture channels but '{}' opened with {}",
+            config.min_channels, device_name, channels
+        )));
+    }
+
     // Calculate ring buffer size based on OUTPUT sample rate (after potential resampling)
     let buffer_size = calculate_ring_buffer_size(target_sample_rate, channels, config.latency_ms);
     let (producer, consumer) = create_ring_buffer(buffer_size);
+    let dropped_frames = Arc::new(AtomicU64::new(0));
 
     // Check if we need resampling
     let needs_resampling = input_sample_rate != target_sample_rate;
@@ -194,6 +394,7 @@ pub fn create_input_stream(
             input_sample_rate,
             target_sample_rate,
             channels,
+            dropped_frames.clone(),
         )?
     } else {
         // Direct passthrough - no resampling needed
@@ -201,6 +402,8 @@ pub fn create_input_stream(
             &device,
             supported_config,
             producer,
+            channels,
+            dropped_frames.clone(),
         )?
     };
 
@@ -210,24 +413,27 @@ pub fn create_input_stream(
         stream,
         consumer: Some(consumer),
         channels,
+        sample_rate: input_sample_rate,
+        dropped_frames,
     })
 }
 
 /// Create a passthrough input stream (no resampling)
+///
+/// The callback runs on the capture thread and must not allocate, lock, or log:
+/// stalling it costs whole capture periods and causes the very overruns it
+/// would be reporting. Dropped frames are counted for the caller to report.
 fn create_passthrough_input_stream(
     device: &Device,
     config: SupportedStreamConfig,
     mut producer: HeapProducer<f32>,
+    channels: usize,
+    dropped_frames: Arc<AtomicU64>,
 ) -> Result<Stream, InputError> {
     let stream = device.build_input_stream(
         &config.into(),
         move |data: &[f32], _: &cpal::InputCallbackInfo| {
-            // Write samples to ring buffer
-            let written = producer.push_slice(data);
-            if written < data.len() {
-                // Ring buffer overflow - samples were dropped
-                tracing::debug!("Input buffer overflow: {} samples dropped", data.len() - written);
-            }
+            push_frames(&mut producer, data, channels, &dropped_frames);
         },
         move |err| {
             tracing::error!("Input stream error: {}", err);
@@ -239,6 +445,10 @@ fn create_passthrough_input_stream(
 }
 
 /// Create a resampling input stream
+///
+/// All working buffers are allocated up front: the callback runs on the capture
+/// thread, where an allocation or a log write costs capture periods and causes
+/// overruns.
 fn create_resampling_input_stream(
     device: &Device,
     config: SupportedStreamConfig,
@@ -246,10 +456,10 @@ fn create_resampling_input_stream(
     input_rate: u32,
     output_rate: u32,
     channels: usize,
+    dropped_frames: Arc<AtomicU64>,
 ) -> Result<Stream, InputError> {
     use rubato::{SincFixedIn, SincInterpolationParameters, SincInterpolationType, WindowFunction, Resampler};
 
-    // Create resampler
     let params = SincInterpolationParameters {
         sinc_len: 256,
         f_cutoff: 0.95,
@@ -260,9 +470,8 @@ fn create_resampling_input_stream(
 
     let resample_ratio = output_rate as f64 / input_rate as f64;
 
-    // We need to handle resampling in the callback, but rubato's resampler isn't Send
-    // So we'll use a simple approach: accumulate samples and resample in chunks
-    let chunk_size = 1024; // Process in chunks
+    // Resample in fixed-size chunks so the resampler's own buffers stay fixed
+    let chunk_size = 1024;
     let mut resampler = SincFixedIn::<f32>::new(
         resample_ratio,
         2.0, // Max relative ratio deviation
@@ -271,48 +480,55 @@ fn create_resampling_input_stream(
         channels,
     ).map_err(|e| InputError::ResamplerError(format!("{:?}", e)))?;
 
-    // Buffer for accumulating input samples before resampling
-    let mut input_buffer: Vec<Vec<f32>> = (0..channels).map(|_| Vec::with_capacity(chunk_size * 2)).collect();
+    let mut resampler_input = resampler.input_buffer_allocate(true);
+    let mut resampler_output = resampler.output_buffer_allocate(true);
+    let max_output_frames = resampler_output.first().map_or(0, |ch| ch.len());
+
+    // Deinterleaved samples accumulated until a full chunk is available
+    let mut pending: Vec<Vec<f32>> = (0..channels)
+        .map(|_| Vec::with_capacity(chunk_size * 2))
+        .collect();
+
+    // Interleaved resampler output, staged here before going into the ring buffer
+    let mut interleaved = vec![0.0f32; max_output_frames * channels];
 
     let stream = device.build_input_stream(
         &config.into(),
         move |data: &[f32], _: &cpal::InputCallbackInfo| {
-            // De-interleave input data into channel buffers
             for (i, sample) in data.iter().enumerate() {
-                let channel = i % channels;
-                input_buffer[channel].push(*sample);
+                pending[i % channels].push(*sample);
             }
 
-            // Process when we have enough samples
-            while input_buffer[0].len() >= chunk_size {
-                // Extract chunk from each channel
-                let input_chunk: Vec<Vec<f32>> = input_buffer.iter_mut()
-                    .map(|ch| ch.drain(..chunk_size).collect())
-                    .collect();
+            while pending[0].len() >= chunk_size {
+                for ch in 0..channels {
+                    resampler_input[ch].clear();
+                    resampler_input[ch].extend(pending[ch].drain(..chunk_size));
+                }
 
-                // Resample
-                match resampler.process(&input_chunk, None) {
-                    Ok(output) => {
-                        // Interleave and write to ring buffer
-                        if !output.is_empty() && !output[0].is_empty() {
-                            let num_frames = output[0].len();
-                            let mut dropped = 0usize;
-                            for frame_idx in 0..num_frames {
-                                for ch in 0..channels {
-                                    if producer.push(output[ch][frame_idx]).is_err() {
-                                        dropped += 1;
-                                    }
-                                }
-                            }
-                            if dropped > 0 {
-                                tracing::debug!("Resampler output overflow: {} samples dropped", dropped);
-                            }
-                        }
+                let frames_out = match resampler
+                    .process_into_buffer(&resampler_input, &mut resampler_output, None)
+                {
+                    Ok((_, frames_out)) => frames_out,
+                    Err(_) => {
+                        // Count the chunk as lost rather than logging from the
+                        // capture thread
+                        dropped_frames.fetch_add(chunk_size as u64, Ordering::Relaxed);
+                        continue;
                     }
-                    Err(e) => {
-                        tracing::error!("Resampling error: {:?}", e);
+                };
+
+                for frame_idx in 0..frames_out {
+                    for ch in 0..channels {
+                        interleaved[frame_idx * channels + ch] = resampler_output[ch][frame_idx];
                     }
                 }
+
+                push_frames(
+                    &mut producer,
+                    &interleaved[..frames_out * channels],
+                    channels,
+                    &dropped_frames,
+                );
             }
         },
         move |err| {
@@ -418,6 +634,99 @@ mod tests {
 
         assert!(config.device_name.is_none());
         assert_eq!(config.latency_ms, 20);
+    }
+
+    #[test]
+    fn test_push_frames_writes_only_whole_frames() {
+        // Room for 2 whole 4-channel frames plus 2 stray samples. Writing the
+        // stray samples would rotate the channel order for every later read.
+        let dropped = Arc::new(AtomicU64::new(0));
+        let (mut producer, consumer) = create_ring_buffer(10);
+
+        let data = vec![1.0f32; 16]; // 4 frames
+        let written = push_frames(&mut producer, &data, 4, &dropped);
+
+        assert_eq!(written, 2, "only whole frames are written");
+        assert_eq!(consumer.len(), 8, "ring buffer holds whole frames only");
+        assert_eq!(dropped.load(Ordering::Relaxed), 2, "two frames did not fit");
+    }
+
+    #[test]
+    fn test_push_frames_writes_everything_when_it_fits() {
+        let dropped = Arc::new(AtomicU64::new(0));
+        let (mut producer, consumer) = create_ring_buffer(64);
+
+        let data = vec![0.25f32; 16]; // 4 frames of 4 channels
+        let written = push_frames(&mut producer, &data, 4, &dropped);
+
+        assert_eq!(written, 4);
+        assert_eq!(consumer.len(), 16);
+        assert_eq!(dropped.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn test_push_frames_keeps_alignment_when_saturated() {
+        // A device that keeps producing while the reader is stalled must never
+        // leave the buffer holding a partial frame.
+        let dropped = Arc::new(AtomicU64::new(0));
+        let (mut producer, consumer) = create_ring_buffer(27);
+        let channels = 5;
+        let data = vec![1.0f32; 5 * channels];
+
+        for _ in 0..10 {
+            push_frames(&mut producer, &data, channels, &dropped);
+            assert_eq!(
+                consumer.len() % channels, 0,
+                "ring buffer must always hold a whole number of frames"
+            );
+        }
+
+        assert!(dropped.load(Ordering::Relaxed) > 0, "saturation should be counted");
+    }
+
+    #[test]
+    fn test_push_frames_ignores_trailing_partial_input() {
+        let dropped = Arc::new(AtomicU64::new(0));
+        let (mut producer, consumer) = create_ring_buffer(64);
+
+        let data = vec![0.5f32; 14]; // 3 whole 4-channel frames plus 2 samples
+        let written = push_frames(&mut producer, &data, 4, &dropped);
+
+        assert_eq!(written, 3);
+        assert_eq!(consumer.len(), 12);
+    }
+
+    #[test]
+    fn test_select_channel_count_uses_smallest_that_covers_routing() {
+        // An interface offering a range should not be opened wider than the
+        // routing needs.
+        assert_eq!(select_channel_count(&[1, 2, 8, 18], None, 3), Some(8));
+        assert_eq!(select_channel_count(&[1, 2, 8, 18], None, 1), Some(1));
+    }
+
+    #[test]
+    fn test_select_channel_count_accepts_fixed_hardware_layout() {
+        // ALSA hw: devices expose only their native layout
+        assert_eq!(select_channel_count(&[18, 20], None, 2), Some(18));
+        assert_eq!(select_channel_count(&[18, 20], None, 19), Some(20));
+    }
+
+    #[test]
+    fn test_select_channel_count_rejects_unreachable_routing() {
+        assert_eq!(select_channel_count(&[1, 2], None, 4), None);
+        assert_eq!(select_channel_count(&[], None, 1), None);
+    }
+
+    #[test]
+    fn test_select_channel_count_honours_explicit_request() {
+        assert_eq!(select_channel_count(&[2, 8, 18], Some(8), 1), Some(8));
+        assert_eq!(select_channel_count(&[2, 8, 18], Some(4), 1), None);
+    }
+
+    #[test]
+    fn test_required_channels_covers_highest_routed_source() {
+        assert_eq!(required_channels(&[(0, 0), (17, 3), (2, 1)]), 18);
+        assert_eq!(required_channels(&[]), 0);
     }
 
     // Note: Device enumeration tests require actual hardware and are skipped in CI

--- a/src/audio/mixer.rs
+++ b/src/audio/mixer.rs
@@ -6,6 +6,8 @@ use crate::audio::ducking::DuckingEngine;
 use crate::audio::bass_management::BassManagement;
 use crate::audio::pitch_correction::PitchCorrector;
 use ringbuf::HeapConsumer;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
 
 /// Fade state for audio samples
 #[derive(Debug, Clone, PartialEq)]
@@ -456,6 +458,26 @@ pub struct LiveInput {
 
     /// Channel routing: vec![(src_channel, dest_channel), ...]
     pub channel_map: Vec<(usize, usize)>,
+
+    /// Interleaved frames read from the ring buffer during a callback.
+    /// Preallocated to the ring buffer's capacity so the audio callback
+    /// never allocates.
+    scratch: Vec<f32>,
+
+    /// Backlog ceiling in frames. Anything beyond this is discarded so that
+    /// capture latency stays bounded when the capture clock outruns the
+    /// output clock.
+    pub max_backlog_frames: usize,
+
+    /// Frames discarded to bring the backlog back under the ceiling
+    pub trimmed_frames: u64,
+
+    /// Frames of silence emitted because the ring buffer was empty
+    pub underrun_frames: u64,
+
+    /// Frames the capture callback could not hand over because the ring
+    /// buffer was full. Shared with the capture thread.
+    pub dropped_frames: Arc<AtomicU64>,
 }
 
 impl LiveInput {
@@ -467,6 +489,9 @@ impl LiveInput {
         volume: f32,
         channel_map: Vec<(usize, usize)>,
     ) -> Self {
+        let channels = input_channels.max(1);
+        let capacity_frames = consumer.capacity() / channels;
+
         Self {
             voice_id,
             consumer,
@@ -475,7 +500,30 @@ impl LiveInput {
             voice_volume: 1.0,
             target_voice_volume: 1.0,
             channel_map,
+            scratch: vec![0.0; capacity_frames * channels],
+            max_backlog_frames: capacity_frames / 2,
+            trimmed_frames: 0,
+            underrun_frames: 0,
+            dropped_frames: Arc::new(AtomicU64::new(0)),
         }
+    }
+
+    /// Share the capture thread's dropped-frame counter so input health can be
+    /// reported from the mixer state
+    pub fn with_dropped_frames(mut self, dropped_frames: Arc<AtomicU64>) -> Self {
+        self.dropped_frames = dropped_frames;
+        self
+    }
+
+    /// Number of whole frames currently waiting in the ring buffer
+    pub fn backlog_frames(&self) -> usize {
+        self.consumer.len() / self.input_channels.max(1)
+    }
+
+    /// Frames the capture callback could not hand over because the ring buffer
+    /// was full
+    pub fn dropped_frames(&self) -> u64 {
+        self.dropped_frames.load(Ordering::Relaxed)
     }
 
     /// Get the combined volume (input volume * voice volume)
@@ -835,6 +883,11 @@ fn mix_sample_with_pitch_correction(
 }
 
 /// Mix a live input (microphone) into the output buffer
+///
+/// Samples are moved out of the ring buffer in whole frames only. A partially
+/// consumed frame would shift the interleaving for every later callback, which
+/// silently reroutes each microphone to the wrong output and leaves a residue
+/// that grows until the ring buffer overflows.
 fn mix_live_input_into_output(
     input: &mut LiveInput,
     output: &mut [f32],
@@ -843,43 +896,54 @@ fn mix_live_input_into_output(
     ducking_multiplier: f32,
 ) {
     let input_channels = input.input_channels;
+    if input_channels == 0 {
+        return;
+    }
     let base_volume = input.volume;
 
-    // Read available samples from the ring buffer
-    // Process frame by frame to handle underruns gracefully
+    // Bound capture latency: a capture clock faster than the output clock
+    // builds a backlog that would otherwise grow until the ring buffer is full.
+    let available_frames = input.consumer.len() / input_channels;
+    if available_frames > input.max_backlog_frames + frames {
+        let excess = available_frames - input.max_backlog_frames;
+        let skipped = input.consumer.skip(excess * input_channels);
+        input.trimmed_frames += (skipped / input_channels) as u64;
+    }
+
+    let mut frames_to_read = frames
+        .min(input.consumer.len() / input_channels)
+        .min(input.scratch.len() / input_channels);
+
+    if frames_to_read > 0 {
+        let samples = frames_to_read * input_channels;
+        let read = input.consumer.pop_slice(&mut input.scratch[..samples]);
+        frames_to_read = read / input_channels;
+    }
+    if frames_to_read < frames {
+        input.underrun_frames += (frames - frames_to_read) as u64;
+    }
+
     for frame_idx in 0..frames {
-        // Advance voice volume toward target (smooth ramping to avoid pops)
+        // Advance voice volume toward target (smooth ramping to avoid pops).
+        // This runs for every output frame, including starved ones, so a fade
+        // still completes on schedule while the input is silent.
         input.advance_voice_volume();
 
-        // Read one frame worth of samples
-        let samples_needed = input_channels;
-        let samples_available = input.consumer.len();
-
-        if samples_available < samples_needed {
-            // Underrun - not enough samples for a complete frame
-            // Leave remaining output as silence (already zeroed)
-            break;
+        if frame_idx >= frames_to_read {
+            // Underrun - leave the remaining output as silence (already zeroed)
+            continue;
         }
 
-        // Read the entire frame from the ring buffer
-        let mut frame_samples = [0.0f32; 16]; // Support up to 16 input channels
-        for ch in 0..input_channels.min(16) {
-            if let Some(sample) = input.consumer.pop() {
-                frame_samples[ch] = sample;
-            }
-        }
-
-        // Calculate volume per-frame to handle smooth ramping
         let final_volume = base_volume * input.voice_volume * ducking_multiplier;
+        let frame_start = frame_idx * input_channels;
 
-        // Apply channel mapping
         for &(src_ch, dest_ch) in &input.channel_map {
-            if src_ch >= input_channels || dest_ch >= output_channels || src_ch >= 16 {
+            if src_ch >= input_channels || dest_ch >= output_channels {
                 continue;
             }
 
             let dest_idx = frame_idx * output_channels + dest_ch;
-            output[dest_idx] += frame_samples[src_ch] * final_volume;
+            output[dest_idx] += input.scratch[frame_start + src_ch] * final_volume;
         }
     }
 }
@@ -1497,6 +1561,21 @@ mod tests {
         consumer
     }
 
+    fn create_test_ring_buffer_with_capacity(data: &[f32], capacity: usize) -> HeapConsumer<f32> {
+        use ringbuf::HeapRb;
+        let rb = HeapRb::<f32>::new(capacity);
+        let (mut producer, consumer) = rb.split();
+        producer.push_slice(data);
+        consumer
+    }
+
+    /// Interleaved test data where each sample's value identifies its channel
+    fn channel_marked_frames(frames: usize, channels: usize) -> Vec<f32> {
+        (0..frames * channels)
+            .map(|i| (i % channels) as f32 / 100.0)
+            .collect()
+    }
+
     #[test]
     fn test_live_input_basic_mixing() {
         // Create ring buffer with stereo data (10 frames)
@@ -1689,6 +1768,285 @@ mod tests {
         // Both inputs mix additively: 0.2 + 0.3 = 0.5
         for &s in &output {
             assert!((s - 0.5).abs() < 0.0001);
+        }
+    }
+
+    #[test]
+    fn test_live_input_high_channel_count() {
+        // Multichannel interfaces expose far more than 16 capture channels.
+        // Every channel must be routable and every sample must be consumed.
+        let channels = 20;
+        let frames = 4;
+        let data = channel_marked_frames(frames, channels);
+        let consumer = create_test_ring_buffer_with_data(&data);
+
+        let live_input = LiveInput::new(
+            "mic".to_string(),
+            consumer,
+            channels,
+            1.0,
+            vec![(17, 0), (19, 1)],
+        );
+
+        let mut state = MixerState::new(2);
+        state.live_inputs.push(live_input);
+
+        let mut output = vec![0.0f32; frames * 2];
+        mix_audio(&mut output, &mut state);
+
+        for f in 0..frames {
+            assert!((output[f * 2] - 0.17).abs() < 1e-6, "input channel 17 routes to output 0");
+            assert!((output[f * 2 + 1] - 0.19).abs() < 1e-6, "input channel 19 routes to output 1");
+        }
+
+        assert_eq!(
+            state.live_inputs[0].consumer.len(), 0,
+            "every consumed frame must be fully drained"
+        );
+    }
+
+    #[test]
+    fn test_live_input_stays_frame_aligned_across_callbacks() {
+        // Leftover samples from a partially consumed frame would rotate the
+        // channel mapping on every subsequent callback.
+        let channels = 20;
+        let data = channel_marked_frames(6, channels);
+        let consumer = create_test_ring_buffer_with_data(&data);
+
+        let live_input = LiveInput::new(
+            "mic".to_string(),
+            consumer,
+            channels,
+            1.0,
+            vec![(3, 0)],
+        );
+
+        let mut state = MixerState::new(1);
+        state.live_inputs.push(live_input);
+
+        for callback in 0..3 {
+            let mut output = vec![0.0f32; 2];
+            mix_audio(&mut output, &mut state);
+            for (i, &s) in output.iter().enumerate() {
+                assert!(
+                    (s - 0.03).abs() < 1e-6,
+                    "callback {} frame {} should still read channel 3, got {}",
+                    callback, i, s
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_live_input_trims_excess_backlog() {
+        // A capture clock running faster than the output clock builds a backlog.
+        // The mixer discards whole frames to bound latency instead of letting
+        // the ring buffer saturate and drop samples at the producer.
+        let channels = 2;
+        let capacity = 400; // 200 frames
+        let data = vec![0.5f32; 380]; // 190 frames queued
+        let consumer = create_test_ring_buffer_with_capacity(&data, capacity);
+
+        let live_input = LiveInput::new(
+            "mic".to_string(),
+            consumer,
+            channels,
+            1.0,
+            vec![(0, 0), (1, 1)],
+        );
+        let max_backlog = live_input.max_backlog_frames;
+        assert!(max_backlog < 190, "test needs a backlog above the ceiling");
+
+        let mut state = MixerState::new(2);
+        state.live_inputs.push(live_input);
+
+        let mut output = vec![0.0f32; 4]; // 2 frames
+        mix_audio(&mut output, &mut state);
+
+        let input = &state.live_inputs[0];
+        assert!(input.trimmed_frames > 0, "excess backlog should be trimmed");
+        assert!(
+            input.consumer.len() / channels <= max_backlog,
+            "backlog must be brought down to the ceiling"
+        );
+        assert_eq!(
+            input.consumer.len() % channels, 0,
+            "trimming must remove whole frames only"
+        );
+    }
+
+    #[test]
+    fn test_live_input_backlog_within_ceiling_is_kept() {
+        let channels = 2;
+        let data = vec![0.5f32; 20]; // 10 frames
+        let consumer = create_test_ring_buffer_with_capacity(&data, 400);
+
+        let live_input = LiveInput::new(
+            "mic".to_string(),
+            consumer,
+            channels,
+            1.0,
+            vec![(0, 0), (1, 1)],
+        );
+
+        let mut state = MixerState::new(2);
+        state.live_inputs.push(live_input);
+
+        let mut output = vec![0.0f32; 4];
+        mix_audio(&mut output, &mut state);
+
+        assert_eq!(state.live_inputs[0].trimmed_frames, 0);
+        assert_eq!(state.live_inputs[0].consumer.len(), 16, "8 frames left");
+    }
+
+    #[test]
+    fn test_live_input_counts_underrun_frames() {
+        let data = vec![0.8f32; 10]; // 5 stereo frames
+        let consumer = create_test_ring_buffer_with_data(&data);
+
+        let live_input = LiveInput::new(
+            "mic".to_string(),
+            consumer,
+            2,
+            1.0,
+            vec![(0, 0), (1, 1)],
+        );
+
+        let mut state = MixerState::new(2);
+        state.live_inputs.push(live_input);
+
+        let mut output = vec![0.0f32; 20]; // 10 frames requested
+        mix_audio(&mut output, &mut state);
+
+        assert_eq!(state.live_inputs[0].underrun_frames, 5);
+    }
+
+    #[test]
+    fn test_live_input_volume_ramp_advances_through_underrun() {
+        // The ramp is wall-clock based: it must keep moving while the input is
+        // starved, otherwise a mute applied during a dropout never completes.
+        let consumer = create_test_ring_buffer_with_data(&[]);
+
+        let mut live_input = LiveInput::new(
+            "mic".to_string(),
+            consumer,
+            1,
+            1.0,
+            vec![(0, 0)],
+        );
+        live_input.set_target_voice_volume(0.0);
+        let before = live_input.voice_volume;
+
+        let mut state = MixerState::new(1);
+        state.live_inputs.push(live_input);
+
+        let mut output = vec![0.0f32; 100];
+        mix_audio(&mut output, &mut state);
+
+        assert!(
+            state.live_inputs[0].voice_volume < before,
+            "voice volume ramp should advance even with no input samples"
+        );
+    }
+
+    #[test]
+    fn test_live_input_ignores_out_of_range_routes() {
+        let data = vec![0.5f32; 8]; // 4 stereo frames
+        let consumer = create_test_ring_buffer_with_data(&data);
+
+        // Source channel 7 does not exist on a stereo input; destination 9
+        // does not exist on a stereo output. Both routes must be skipped
+        // without disturbing the valid one.
+        let live_input = LiveInput::new(
+            "mic".to_string(),
+            consumer,
+            2,
+            1.0,
+            vec![(7, 0), (0, 9), (1, 1)],
+        );
+
+        let mut state = MixerState::new(2);
+        state.live_inputs.push(live_input);
+
+        let mut output = vec![0.0f32; 8];
+        mix_audio(&mut output, &mut state);
+
+        for f in 0..4 {
+            assert_eq!(output[f * 2], 0.0);
+            assert_eq!(output[f * 2 + 1], 0.5);
+        }
+    }
+
+    #[test]
+    fn test_multiple_mics_on_one_interface() {
+        // Four microphones on an 18-channel interface: two summed onto a shared
+        // house speaker, two sent to their own endpoints, each at its own level.
+        let channels = 18;
+        let frames = 8;
+        let data = channel_marked_frames(frames, channels);
+        let consumer = create_test_ring_buffer_with_data(&data);
+
+        let mut mics = LiveInput::new(
+            "gamemaster".to_string(),
+            consumer,
+            channels,
+            0.5,
+            vec![
+                (0, 4),  // mic 1 -> house speaker
+                (1, 4),  // mic 2 -> house speaker (summed with mic 1)
+                (8, 5),  // mic 3 -> its own endpoint
+                (17, 6), // mic 4 -> its own endpoint
+            ],
+        );
+        mics.voice_volume = 1.0;
+        mics.target_voice_volume = 1.0;
+
+        let mut state = MixerState::new(8);
+        state.live_inputs.push(mics);
+
+        let mut output = vec![0.0f32; frames * 8];
+        mix_audio(&mut output, &mut state);
+
+        for f in 0..frames {
+            let base = f * 8;
+            // 0.00 + 0.01 summed, then halved by the input volume
+            assert!((output[base + 4] - 0.005).abs() < 1e-6, "mics 1 and 2 sum on channel 4");
+            assert!((output[base + 5] - 0.04).abs() < 1e-6, "mic 3 on channel 5");
+            assert!((output[base + 6] - 0.085).abs() < 1e-6, "mic 4 on channel 6");
+            assert_eq!(output[base], 0.0, "unrouted channels stay silent");
+            assert_eq!(output[base + 7], 0.0, "unrouted channels stay silent");
+        }
+
+        assert_eq!(state.live_inputs[0].underrun_frames, 0);
+        assert_eq!(state.live_inputs[0].trimmed_frames, 0);
+    }
+
+    #[test]
+    fn test_separate_mic_devices_mix_and_duck_independently() {
+        // Two microphones on separate capture devices, each its own voice, so
+        // they can be levelled and ducked independently while summing to the
+        // same speaker.
+        let consumer1 = create_test_ring_buffer_with_data(&vec![0.4f32; 8]);
+        let consumer2 = create_test_ring_buffer_with_data(&vec![0.6f32; 8]);
+
+        let mut mic1 = LiveInput::new("mic_north".to_string(), consumer1, 1, 0.5, vec![(0, 2)]);
+        mic1.voice_volume = 1.0;
+        mic1.target_voice_volume = 1.0;
+
+        let mut mic2 = LiveInput::new("mic_south".to_string(), consumer2, 1, 1.0, vec![(0, 2)]);
+        mic2.voice_volume = 0.5;
+        mic2.target_voice_volume = 0.5;
+
+        let mut state = MixerState::new(4);
+        state.live_inputs.push(mic1);
+        state.live_inputs.push(mic2);
+
+        let mut output = vec![0.0f32; 8 * 4];
+        mix_audio(&mut output, &mut state);
+
+        // 0.4 * 0.5 + 0.6 * 0.5 = 0.5 on the shared destination
+        for f in 0..8 {
+            assert!((output[f * 4 + 2] - 0.5).abs() < 1e-6);
         }
     }
 

--- a/src/audio/mixer.rs
+++ b/src/audio/mixer.rs
@@ -368,7 +368,7 @@ impl ActiveSample {
 
     /// Set target voice volume for smooth ramping
     pub fn set_target_voice_volume(&mut self, target: f32) {
-        self.target_voice_volume = target.clamp(0.0, 1.0);
+        self.target_voice_volume = target.clamp(0.0, crate::config::MAX_GAIN);
     }
 
     /// Advance voice volume toward target by one frame.
@@ -535,7 +535,7 @@ impl LiveInput {
     /// Set target voice volume for smooth ramping
     #[allow(dead_code)]
     pub fn set_target_voice_volume(&mut self, target: f32) {
-        self.target_voice_volume = target.clamp(0.0, 1.0);
+        self.target_voice_volume = target.clamp(0.0, crate::config::MAX_GAIN);
     }
 
     /// Advance voice volume toward target by one frame.
@@ -564,6 +564,10 @@ pub struct MixerState {
     /// Number of output channels
     pub output_channels: usize,
 
+    /// Per-channel output gain, indexed by channel. Unity is 1.0.
+    /// Applied last, so it levels the finished mix including bass management.
+    pub channel_gains: Vec<f32>,
+
     /// Ducking engine for automatic voice volume reduction
     pub ducking_engine: Option<DuckingEngine>,
 
@@ -578,6 +582,7 @@ impl MixerState {
             active_samples: Vec::new(),
             live_inputs: Vec::new(),
             output_channels,
+            channel_gains: vec![1.0; output_channels],
             ducking_engine: None,
             bass_management: None,
         }
@@ -627,6 +632,17 @@ pub fn mix_audio(output: &mut [f32], state: &mut MixerState) {
     // Apply bass management (LFE extraction and crossover filtering)
     if let Some(ref mut bm) = state.bass_management {
         bm.process(output, state.output_channels);
+    }
+
+    // Apply per-channel calibration to the finished mix
+    if state.channel_gains.iter().any(|g| *g != 1.0) {
+        for frame in output.chunks_mut(state.output_channels) {
+            for (ch, sample) in frame.iter_mut().enumerate() {
+                if let Some(gain) = state.channel_gains.get(ch) {
+                    *sample *= gain;
+                }
+            }
+        }
     }
 
     // Apply saturation to prevent clipping
@@ -2047,6 +2063,119 @@ mod tests {
         // 0.4 * 0.5 + 0.6 * 0.5 = 0.5 on the shared destination
         for f in 0..8 {
             assert!((output[f * 4 + 2] - 0.5).abs() < 1e-6);
+        }
+    }
+
+    #[test]
+    fn test_channel_gains_applied() {
+        let buffer = create_test_buffer(4, 2, 0.4);
+        let sample = ActiveSample::new(1, "test".to_string(), buffer, 1.0, 1.0, TEST_FILE.to_string());
+
+        let mut state = MixerState::new(2);
+        state.channel_gains = vec![0.5, 1.0];
+        state.active_samples.push(sample);
+
+        let mut output = vec![0.0f32; 8];
+        mix_audio(&mut output, &mut state);
+
+        for f in 0..4 {
+            assert!((output[f * 2] - 0.2).abs() < 1e-6, "channel 0 attenuated");
+            assert!((output[f * 2 + 1] - 0.4).abs() < 1e-6, "channel 1 left alone");
+        }
+    }
+
+    #[test]
+    fn test_channel_gains_can_boost() {
+        // Lifting an underpowered subwoofer channel above unity
+        let buffer = create_test_buffer(4, 2, 0.3);
+        let sample = ActiveSample::new(1, "test".to_string(), buffer, 1.0, 1.0, TEST_FILE.to_string());
+
+        let mut state = MixerState::new(2);
+        state.channel_gains = vec![1.0, 2.0];
+        state.active_samples.push(sample);
+
+        let mut output = vec![0.0f32; 8];
+        mix_audio(&mut output, &mut state);
+
+        for f in 0..4 {
+            assert!((output[f * 2 + 1] - 0.6).abs() < 1e-6, "channel 1 boosted");
+        }
+    }
+
+    #[test]
+    fn test_channel_gains_still_saturate() {
+        // A boost cannot push the output past full scale
+        let buffer = create_test_buffer(4, 1, 0.8);
+        let sample = ActiveSample::new(1, "test".to_string(), buffer, 1.0, 1.0, TEST_FILE.to_string());
+
+        let mut state = MixerState::new(1);
+        state.channel_gains = vec![4.0];
+        state.active_samples.push(sample);
+
+        let mut output = vec![0.0f32; 4];
+        mix_audio(&mut output, &mut state);
+
+        for &s in &output {
+            assert_eq!(s, 1.0);
+        }
+    }
+
+    #[test]
+    fn test_boosted_sample_volume_saturates() {
+        let buffer = create_test_buffer(4, 1, 0.6);
+        let sample = ActiveSample::new(1, "test".to_string(), buffer, 1.0, 3.0, TEST_FILE.to_string());
+
+        let mut state = MixerState::new(1);
+        state.active_samples.push(sample);
+
+        let mut output = vec![0.0f32; 4];
+        mix_audio(&mut output, &mut state);
+
+        for &s in &output {
+            assert_eq!(s, 1.0);
+        }
+    }
+
+    #[test]
+    fn test_set_target_voice_volume_allows_boost() {
+        let buffer = create_test_buffer(4, 1, 0.1);
+        let mut sample = ActiveSample::new(1, "test".to_string(), buffer, 1.0, 1.0, TEST_FILE.to_string());
+
+        sample.set_target_voice_volume(2.5);
+        assert_eq!(sample.target_voice_volume, 2.5);
+
+        sample.set_target_voice_volume(100.0);
+        assert_eq!(sample.target_voice_volume, crate::config::MAX_GAIN);
+    }
+
+    #[test]
+    fn test_live_input_target_voice_volume_allows_boost() {
+        let consumer = create_test_ring_buffer_with_data(&[0.1f32; 4]);
+        let mut input = LiveInput::new("mic".to_string(), consumer, 1, 1.0, vec![(0, 0)]);
+
+        input.set_target_voice_volume(2.5);
+        assert_eq!(input.target_voice_volume, 2.5);
+
+        input.set_target_voice_volume(100.0);
+        assert_eq!(input.target_voice_volume, crate::config::MAX_GAIN);
+    }
+
+    #[test]
+    fn test_live_input_volume_can_boost() {
+        // A quiet microphone lifted above unity
+        let consumer = create_test_ring_buffer_with_data(&[0.2f32; 4]);
+        let mut input = LiveInput::new("mic".to_string(), consumer, 1, 3.0, vec![(0, 0)]);
+        input.voice_volume = 1.0;
+        input.target_voice_volume = 1.0;
+
+        let mut state = MixerState::new(1);
+        state.live_inputs.push(input);
+
+        let mut output = vec![0.0f32; 4];
+        mix_audio(&mut output, &mut state);
+
+        for &s in &output {
+            assert!((s - 0.6).abs() < 1e-6);
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -276,6 +276,10 @@ pub struct InputConfig {
     pub routes: Vec<InputRouteConfig>,
     /// Buffer latency in milliseconds
     pub latency_ms: u32,
+    /// Capture channel count to open (None = smallest count the routes need)
+    pub channels: Option<usize>,
+    /// Capture sample rate to request (None = match the output sample rate)
+    pub sample_rate: Option<u32>,
 }
 
 impl Default for InputConfig {
@@ -286,6 +290,8 @@ impl Default for InputConfig {
             voice_id: "mic".to_string(),
             routes: Vec::new(),
             latency_ms: 20,
+            channels: None,
+            sample_rate: None,
         }
     }
 }
@@ -741,6 +747,16 @@ impl Config {
             }
             if input.latency_ms < 5 || input.latency_ms > 500 {
                 errors.push(format!("inputs[{}].latency_ms must be between 5 and 500", i));
+            }
+            if let Some(channels) = input.channels {
+                if channels == 0 || channels > 64 {
+                    errors.push(format!("inputs[{}].channels must be between 1 and 64", i));
+                }
+            }
+            if let Some(rate) = input.sample_rate {
+                if !(8000..=192000).contains(&rate) {
+                    errors.push(format!("inputs[{}].sample_rate must be between 8000 and 192000", i));
+                }
             }
             // Validate channel aliases in routes
             for (j, route) in input.routes.iter().enumerate() {
@@ -1393,6 +1409,8 @@ mod tests {
                 InputRouteConfig { source_channel: ChannelRef::Index(0), dest_channel: ChannelRef::Index(1) },
             ],
             latency_ms: 25,
+            channels: None,
+            sample_rate: None,
         });
 
         let result = config.validate();

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,6 +7,14 @@ use std::path::{Path, PathBuf};
 use std::fs;
 use crate::audio::ducking::DuckingRule;
 
+/// Highest gain any volume control accepts.
+///
+/// Unity is 1.0; 4.0 is +12 dB, enough to lift a quiet microphone or an
+/// underpowered subwoofer without letting a mistyped value destroy a speaker.
+/// The mixer saturates its output regardless, so boosted material clips rather
+/// than wrapping.
+pub const MAX_GAIN: f32 = 4.0;
+
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(default)]
 pub struct MqttConfig {
@@ -70,7 +78,10 @@ impl ChannelRef {
             ChannelRef::Alias(name) => {
                 aliases.get(name)
                     .copied()
-                    .ok_or_else(|| format!("Unknown channel alias: '{}'", name))
+                    .ok_or_else(|| format!(
+                        "Unknown channel '{}': define it in audio.channel_aliases as \"{}\": <channel number>",
+                        name, name
+                    ))
             }
         }
     }
@@ -611,8 +622,26 @@ impl Config {
     }
 
     /// Resolve a channel reference to a numeric index using this config's aliases
+    ///
+    /// `audio.channel_names` labels channels for display and `audio.channel_aliases`
+    /// is what routing resolves against. Naming a channel in the first and using it
+    /// in a route is the easiest mistake to make with this config, so a name found
+    /// only in `channel_names` is reported with the entry needed to fix it.
     pub fn resolve_channel(&self, channel: &ChannelRef) -> Result<usize, String> {
-        channel.resolve(&self.audio.channel_aliases)
+        channel.resolve(&self.audio.channel_aliases).map_err(|e| {
+            let ChannelRef::Alias(name) = channel else {
+                return e;
+            };
+
+            match self.audio.channel_names.iter().find(|(_, label)| *label == name) {
+                Some((index, _)) => format!(
+                    "Unknown channel '{}': audio.channel_names labels channel {} as '{}', \
+                     but routing resolves against audio.channel_aliases - add \"{}\": {} there",
+                    name, index, name, name, index
+                ),
+                None => e,
+            }
+        })
     }
 
     /// Resolve bass management channel references to numeric indices
@@ -629,6 +658,52 @@ impl Config {
             source_channels: sources?,
             remove_bass_from_sources: self.bass_management.remove_bass_from_sources,
         })
+    }
+
+    /// Resolve a channel_volumes key to a channel index.
+    ///
+    /// Keys may be a channel number, an alias from `audio.channel_aliases`, or
+    /// a name from `audio.channel_names`, so levelling works whichever way the
+    /// channels were labelled.
+    fn resolve_channel_volume_key(&self, key: &str) -> Result<usize, String> {
+        if let Ok(index) = key.parse::<usize>() {
+            return Ok(index);
+        }
+
+        if let Some(index) = self.audio.channel_aliases.get(key) {
+            return Ok(*index);
+        }
+
+        for (index, name) in &self.audio.channel_names {
+            if name == key {
+                return index.parse::<usize>().map_err(|_| {
+                    format!("channel_names key '{}' is not a channel number", index)
+                });
+            }
+        }
+
+        Err(format!(
+            "'{}' is not a channel number, an audio.channel_aliases entry, or an audio.channel_names value",
+            key
+        ))
+    }
+
+    /// Per-channel output gains, indexed by channel number.
+    ///
+    /// Channels with no entry in `audio.channel_volumes` are left at unity.
+    /// Entries beyond the output channel count are ignored, so a config shared
+    /// between a wide and a narrow device still loads.
+    pub fn resolve_channel_gains(&self, output_channels: usize) -> Result<Vec<f32>, String> {
+        let mut gains = vec![1.0; output_channels];
+
+        for (key, gain) in &self.audio.channel_volumes {
+            let index = self.resolve_channel_volume_key(key)?;
+            if index < output_channels {
+                gains[index] = *gain;
+            }
+        }
+
+        Ok(gains)
     }
 
     /// Resolve input route channel references to numeric indices
@@ -704,10 +779,16 @@ impl Config {
             errors.push("audio.buffer_size must be between 64 and 8192".to_string());
         }
 
-        // Channel volumes must be 0.0 to 1.0
+        // Channel volumes are gains: unity is 1.0, above that boosts
         for (ch, vol) in &self.audio.channel_volumes {
-            if *vol < 0.0 || *vol > 1.0 {
-                errors.push(format!("audio.channel_volumes.{} must be between 0.0 and 1.0", ch));
+            if *vol < 0.0 || *vol > MAX_GAIN {
+                errors.push(format!(
+                    "audio.channel_volumes.{} must be between 0.0 and {}",
+                    ch, MAX_GAIN
+                ));
+            }
+            if let Err(e) = self.resolve_channel_volume_key(ch) {
+                errors.push(format!("audio.channel_volumes.{}: {}", ch, e));
             }
         }
 
@@ -739,8 +820,11 @@ impl Config {
 
         // Input validation
         for (i, input) in self.inputs.iter().enumerate() {
-            if input.volume < 0.0 || input.volume > 1.0 {
-                errors.push(format!("inputs[{}].volume must be between 0.0 and 1.0", i));
+            if input.volume < 0.0 || input.volume > MAX_GAIN {
+                errors.push(format!(
+                    "inputs[{}].volume must be between 0.0 and {}",
+                    i, MAX_GAIN
+                ));
             }
             if input.routes.is_empty() {
                 errors.push(format!("inputs[{}].routes must not be empty", i));
@@ -1102,7 +1186,7 @@ mod tests {
     fn test_validate_invalid_channel_volume() {
         let mut config = Config::default();
         config.mqtt.topic = Some("test".to_string());
-        config.audio.channel_volumes.insert("0".to_string(), 1.5);
+        config.audio.channel_volumes.insert("0".to_string(), -0.5);
 
         let result = config.validate();
         assert!(result.is_err());
@@ -1350,11 +1434,157 @@ mod tests {
     }
 
     #[test]
+    fn test_unknown_alias_error_names_the_alias_map() {
+        let config = Config::default();
+        let err = config.resolve_channel(&ChannelRef::Alias("booth".to_string())).unwrap_err();
+
+        assert!(err.contains("booth"));
+        assert!(
+            err.contains("channel_aliases"),
+            "the error should say which map to add the name to, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_unknown_alias_error_points_at_channel_names() {
+        // channel_names is index -> name for display; routing resolves against
+        // channel_aliases. Naming a channel in the wrong map is the easiest
+        // mistake to make, so the error has to say so.
+        let mut config = Config::default();
+        config.audio.channel_names.insert("6".to_string(), "booth".to_string());
+
+        let err = config.resolve_channel(&ChannelRef::Alias("booth".to_string())).unwrap_err();
+
+        assert!(err.contains("channel_names"), "got: {}", err);
+        assert!(err.contains("channel_aliases"), "got: {}", err);
+        assert!(err.contains("6"), "the error should name the channel it found: {}", err);
+    }
+
+    #[test]
+    fn test_input_route_error_points_at_channel_names() {
+        let mut config = Config::default();
+        config.mqtt.topic = Some("test".to_string());
+        config.audio.channel_names.insert("4".to_string(), "house".to_string());
+        config.inputs.push(InputConfig {
+            routes: vec![InputRouteConfig {
+                source_channel: ChannelRef::Index(0),
+                dest_channel: ChannelRef::Alias("house".to_string()),
+            }],
+            ..Default::default()
+        });
+
+        let errors = config.validate().unwrap_err();
+        assert!(
+            errors.iter().any(|e| e.contains("channel_names") && e.contains("channel_aliases")),
+            "validation should explain the two maps, got: {:?}",
+            errors
+        );
+    }
+
+    #[test]
+    fn test_channel_volumes_allow_boost() {
+        let mut config = Config::default();
+        config.mqtt.topic = Some("test".to_string());
+        config.audio.channel_volumes.insert("3".to_string(), 1.5);
+
+        assert!(config.validate().is_ok(), "boosting a channel above unity is allowed");
+    }
+
+    #[test]
+    fn test_channel_volumes_reject_excessive_gain() {
+        let mut config = Config::default();
+        config.mqtt.topic = Some("test".to_string());
+        config.audio.channel_volumes.insert("3".to_string(), MAX_GAIN + 1.0);
+
+        let errors = config.validate().unwrap_err();
+        assert!(errors.iter().any(|e| e.contains("channel_volumes")));
+    }
+
+    #[test]
+    fn test_input_volume_allows_boost() {
+        let mut config = Config::default();
+        config.mqtt.topic = Some("test".to_string());
+        config.inputs.push(InputConfig {
+            volume: 2.0,
+            routes: vec![InputRouteConfig { source_channel: ChannelRef::Index(0), dest_channel: ChannelRef::Index(0) }],
+            ..Default::default()
+        });
+
+        assert!(config.validate().is_ok(), "a quiet microphone can be boosted");
+    }
+
+    #[test]
+    fn test_input_volume_rejects_excessive_gain() {
+        let mut config = Config::default();
+        config.mqtt.topic = Some("test".to_string());
+        config.inputs.push(InputConfig {
+            volume: MAX_GAIN + 1.0,
+            routes: vec![InputRouteConfig { source_channel: ChannelRef::Index(0), dest_channel: ChannelRef::Index(0) }],
+            ..Default::default()
+        });
+
+        let errors = config.validate().unwrap_err();
+        assert!(errors.iter().any(|e| e.contains("volume")));
+    }
+
+    #[test]
+    fn test_resolve_channel_gains_by_index() {
+        let mut config = Config::default();
+        config.audio.channel_volumes.insert("0".to_string(), 0.5);
+        config.audio.channel_volumes.insert("3".to_string(), 1.5);
+
+        let gains = config.resolve_channel_gains(4).unwrap();
+        assert_eq!(gains, vec![0.5, 1.0, 1.0, 1.5]);
+    }
+
+    #[test]
+    fn test_resolve_channel_gains_by_alias() {
+        let mut config = Config::default();
+        config.audio.channel_aliases.insert("sub".to_string(), 3);
+        config.audio.channel_volumes.insert("sub".to_string(), 1.8);
+
+        let gains = config.resolve_channel_gains(4).unwrap();
+        assert_eq!(gains[3], 1.8);
+    }
+
+    #[test]
+    fn test_resolve_channel_gains_by_channel_name() {
+        // channel_names is index -> name, and the example config levels
+        // channels using those names
+        let mut config = Config::default();
+        config.audio.channel_names.insert("3".to_string(), "lfe".to_string());
+        config.audio.channel_volumes.insert("lfe".to_string(), 1.2);
+
+        let gains = config.resolve_channel_gains(4).unwrap();
+        assert_eq!(gains[3], 1.2);
+    }
+
+    #[test]
+    fn test_resolve_channel_gains_ignores_channels_beyond_output() {
+        let mut config = Config::default();
+        config.audio.channel_volumes.insert("9".to_string(), 0.5);
+
+        let gains = config.resolve_channel_gains(2).unwrap();
+        assert_eq!(gains, vec![1.0, 1.0]);
+    }
+
+    #[test]
+    fn test_channel_volumes_unknown_name_is_an_error() {
+        let mut config = Config::default();
+        config.mqtt.topic = Some("test".to_string());
+        config.audio.channel_volumes.insert("nowhere".to_string(), 0.5);
+
+        let errors = config.validate().unwrap_err();
+        assert!(errors.iter().any(|e| e.contains("nowhere")));
+    }
+
+    #[test]
     fn test_input_validation_invalid_volume() {
         let mut config = Config::default();
         config.mqtt.topic = Some("test".to_string());
         config.inputs.push(InputConfig {
-            volume: 1.5, // Invalid
+            volume: -0.5, // Invalid
             routes: vec![InputRouteConfig { source_channel: ChannelRef::Index(0), dest_channel: ChannelRef::Index(0) }],
             ..Default::default()
         });

--- a/src/http/handlers.rs
+++ b/src/http/handlers.rs
@@ -680,7 +680,12 @@ pub async fn handle_inputs(State(state): State<AppState>) -> impl IntoResponse {
                 "voice_id": input.voice_id,
                 "volume": input.volume,
                 "channels": input.input_channels,
-                "muted": input.volume == 0.0
+                "muted": input.volume == 0.0,
+                "backlog_frames": input.backlog_frames(),
+                "max_backlog_frames": input.max_backlog_frames,
+                "dropped_frames": input.dropped_frames(),
+                "trimmed_frames": input.trimmed_frames,
+                "underrun_frames": input.underrun_frames
             })
         })
         .collect();

--- a/src/http/handlers.rs
+++ b/src/http/handlers.rs
@@ -220,6 +220,36 @@ pub async fn handle_stopall(State(state): State<AppState>) -> impl IntoResponse 
 }
 
 #[derive(Deserialize, Default)]
+pub struct FadeAllParams {
+    /// Fade duration in milliseconds. Omitted means the daemon's default.
+    #[serde(default)]
+    time: Option<u32>,
+}
+
+pub async fn handle_fadeall(
+    State(state): State<AppState>,
+    Json(params): Json<FadeAllParams>,
+) -> impl IntoResponse {
+    let mut message = json!({});
+    if let Some(time) = params.time {
+        message["time"] = json!(time);
+    }
+
+    let command = json!({
+        "command": "fadeall",
+        "message": message
+    });
+
+    match send_command(&state, &command.to_string()).await {
+        Ok(()) => (StatusCode::OK, Json(CommandResponse::ok())),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(CommandResponse::error(&e)),
+        ),
+    }
+}
+
+#[derive(Deserialize, Default)]
 pub struct VolumeParams {
     #[serde(default)]
     internal_id: Option<String>,

--- a/src/http/routes.rs
+++ b/src/http/routes.rs
@@ -68,6 +68,7 @@ pub fn create_router(state: AppState, cors_permissive: bool, websocket_enabled: 
         .route("/play", post(handlers::handle_play))
         .route("/stop", post(handlers::handle_stop))
         .route("/stopall", post(handlers::handle_stopall))
+        .route("/fadeall", post(handlers::handle_fadeall))
         .route("/volume", post(handlers::handle_volume))
         .route("/seek", post(handlers::handle_seek))
         .route("/speed", post(handlers::handle_speed))

--- a/src/main.rs
+++ b/src/main.rs
@@ -491,10 +491,19 @@ async fn main() {
         None
     };
 
+    let channel_gains = config.resolve_channel_gains(output_channels)
+        .expect("Channel volume resolution failed (should have been caught during validation)");
+    for (channel, gain) in channel_gains.iter().enumerate() {
+        if *gain != 1.0 {
+            tracing::info!("Channel {} gain: {:.2}", channel, gain);
+        }
+    }
+
     let mixer_state = Arc::new(Mutex::new(MixerState {
         active_samples: Vec::new(),
         live_inputs: Vec::new(),
         output_channels,
+        channel_gains,
         ducking_engine,
         bass_management,
     }));
@@ -896,6 +905,19 @@ async fn main() {
 
                             tracing::info!("Stopping {} samples ({}ms fade-out)", count, STOP_FADE_MS);
                         }
+                        mqtt::commands::AudioCommand::FadeAll { time_ms } => {
+                            let mut state = mixer_state.lock().unwrap();
+                            let count = state.active_samples.len();
+
+                            for sample in state.active_samples.iter_mut() {
+                                sample.set_fade(audio::mixer::FadeState::fade_out(time_ms, output_sample_rate));
+                            }
+                            drop(state);
+
+                            // Samples are removed by the audio callback once the
+                            // fade completes, and voice cleanup follows from that.
+                            tracing::info!("Fading out {} samples over {}ms", count, time_ms);
+                        }
                         mqtt::commands::AudioCommand::VoiceStop { voice } => {
                             // Apply quick 10ms fade-out to prevent clicks/pops
                             const STOP_FADE_MS: u32 = 10;
@@ -1046,7 +1068,7 @@ async fn main() {
                             // Try to find by index first
                             if let Ok(idx) = input.parse::<usize>() {
                                 if idx < state.live_inputs.len() {
-                                    state.live_inputs[idx].volume = new_volume.clamp(0.0, 1.0);
+                                    state.live_inputs[idx].volume = new_volume.clamp(0.0, config::MAX_GAIN);
                                     tracing::info!(
                                         "Set input {} volume to {:.2}",
                                         idx, state.live_inputs[idx].volume
@@ -1059,7 +1081,7 @@ async fn main() {
                             if !found {
                                 for live_input in state.live_inputs.iter_mut() {
                                     if live_input.voice_id == input {
-                                        live_input.volume = new_volume.clamp(0.0, 1.0);
+                                        live_input.volume = new_volume.clamp(0.0, config::MAX_GAIN);
                                         tracing::info!(
                                             "Set input '{}' volume to {:.2}",
                                             input, live_input.volume
@@ -1223,7 +1245,7 @@ async fn main() {
                                         &sample.file_path,
                                         &sample.voice_id,
                                     ) {
-                                        sample.volume = volume.clamp(0.0, 1.0);
+                                        sample.volume = volume.clamp(0.0, config::MAX_GAIN);
                                         updated_count += 1;
                                     }
                                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -99,6 +99,73 @@ struct Args {
     max_cache_mb: Option<u32>,
 }
 
+/// Report capture health for live inputs on a fixed interval.
+///
+/// Overruns, backlog trims and starvation are counted inside the audio
+/// callbacks, which must not log or allocate; this reports the deltas from an
+/// ordinary task so problems are visible without stalling the audio threads.
+fn spawn_input_health_monitor(
+    mixer_state: std::sync::Arc<std::sync::Mutex<audio::mixer::MixerState>>,
+) {
+    const INTERVAL_SECS: u64 = 10;
+
+    tokio::spawn(async move {
+        let mut previous: Vec<(u64, u64, u64)> = Vec::new();
+        let mut ticker =
+            tokio::time::interval(std::time::Duration::from_secs(INTERVAL_SECS));
+        ticker.tick().await; // the first tick completes immediately
+
+        loop {
+            ticker.tick().await;
+
+            let snapshot: Vec<(String, usize, u64, u64, u64)> = {
+                let state = mixer_state.lock().unwrap();
+                state
+                    .live_inputs
+                    .iter()
+                    .map(|i| {
+                        (
+                            i.voice_id.clone(),
+                            i.backlog_frames(),
+                            i.dropped_frames(),
+                            i.trimmed_frames,
+                            i.underrun_frames,
+                        )
+                    })
+                    .collect()
+            };
+
+            previous.resize(snapshot.len(), (0, 0, 0));
+
+            for (idx, (voice_id, backlog, dropped, trimmed, underrun)) in
+                snapshot.iter().enumerate()
+            {
+                let (prev_dropped, prev_trimmed, prev_underrun) = previous[idx];
+                previous[idx] = (*dropped, *trimmed, *underrun);
+
+                let new_dropped = dropped.saturating_sub(prev_dropped);
+                let new_trimmed = trimmed.saturating_sub(prev_trimmed);
+                let new_underrun = underrun.saturating_sub(prev_underrun);
+
+                if new_dropped == 0 && new_trimmed == 0 && new_underrun == 0 {
+                    continue;
+                }
+
+                tracing::warn!(
+                    "Input {} ('{}'): {} frames overran, {} trimmed, {} starved in {}s (backlog {} frames)",
+                    idx,
+                    voice_id,
+                    new_dropped,
+                    new_trimmed,
+                    new_underrun,
+                    INTERVAL_SECS,
+                    backlog
+                );
+            }
+        }
+    });
+}
+
 #[tokio::main]
 async fn main() {
     let args = Args::parse();
@@ -436,26 +503,31 @@ async fn main() {
     // Keep active input streams alive - they will be kept alive until the app exits
     let mut _active_inputs: Vec<audio::input::ActiveInput> = Vec::new();
     for (idx, input_config) in config.inputs.iter().enumerate() {
+        // Resolve routing first: it determines how many capture channels the
+        // stream has to be opened with.
+        let channel_map: Vec<(usize, usize)> = config.resolve_input_routes(&input_config.routes)
+            .expect("Channel alias resolution failed (should have been caught during validation)");
+
         let stream_config = audio::input::InputStreamConfig {
             device_name: input_config.device.clone(),
             latency_ms: input_config.latency_ms,
+            channels: input_config.channels,
+            min_channels: audio::input::required_channels(&channel_map),
+            sample_rate: input_config.sample_rate,
         };
 
         match audio::input::create_input_stream(stream_config, output_sample_rate) {
             Ok(mut active_input) => {
                 tracing::info!(
-                    "Opened input device: {} ({} channels, voice '{}')",
+                    "Opened input device: {} ({} channels, {} Hz, voice '{}')",
                     input_config.device.as_deref().unwrap_or("default"),
                     active_input.channels,
+                    active_input.sample_rate,
                     input_config.voice_id
                 );
 
                 // Take ownership of the consumer for the mixer
                 if let Some(consumer) = active_input.take_consumer() {
-                    // Build channel map from routes config (resolve aliases)
-                    let channel_map: Vec<(usize, usize)> = config.resolve_input_routes(&input_config.routes)
-                        .expect("Channel alias resolution failed (should have been caught during validation)");
-
                     tracing::info!(
                         "Input {} routed: {:?}",
                         idx,
@@ -471,7 +543,7 @@ async fn main() {
                         active_input.channels,
                         input_config.volume,
                         channel_map,
-                    );
+                    ).with_dropped_frames(active_input.dropped_frames.clone());
 
                     // Add to mixer state
                     mixer_state.lock().unwrap().live_inputs.push(live_input);
@@ -488,6 +560,10 @@ async fn main() {
                 );
             }
         }
+    }
+
+    if !mixer_state.lock().unwrap().live_inputs.is_empty() {
+        spawn_input_health_monitor(mixer_state.clone());
     }
 
     let voice_manager = Arc::new(Mutex::new(VoiceManager::new()));

--- a/src/mqtt/commands.rs
+++ b/src/mqtt/commands.rs
@@ -4,6 +4,9 @@
 use serde::{Deserialize, Serialize};
 use crate::config::ChannelRef;
 
+/// Fade duration used when a fadeall command does not name one
+pub const DEFAULT_FADE_ALL_MS: u32 = 1000;
+
 /// MQTT command envelope supporting both flattened and nested formats.
 /// Flattened: {"command": "play", "file": "test.wav", "volume": 0.8}
 /// Nested (legacy): {"command": "play", "message": {"file": "test.wav", "volume": 0.8}}
@@ -144,6 +147,15 @@ pub struct VoiceFadeOutMessage {
     pub time: u32, // milliseconds
 }
 
+/// Fade-all command parameters
+#[derive(Debug, Deserialize, Serialize)]
+pub struct FadeAllMessage {
+    /// Fade duration in milliseconds. Also accepted as "fade_out_ms",
+    /// matching the field name the stop command uses.
+    #[serde(alias = "fade_out_ms")]
+    pub time: Option<u32>,
+}
+
 /// Voice volume command parameters
 #[derive(Debug, Deserialize, Serialize)]
 pub struct VoiceVolumeMessage {
@@ -274,6 +286,9 @@ pub enum AudioCommand {
         crossfade_ms: u32, // Crossfade duration at loop boundaries (0 = disabled)
     },
     StopAll,
+    FadeAll {
+        time_ms: u32,
+    },
     VoiceStop {
         voice: String,
     },
@@ -429,7 +444,7 @@ pub fn parse_command(json: &str) -> Result<AudioCommand, ParseError> {
             Ok(AudioCommand::Play {
                 file: play_msg.file,
                 id: play_msg.id,
-                volume: play_msg.volume.unwrap_or(1.0),
+                volume: play_msg.volume.unwrap_or(1.0).clamp(0.0, crate::config::MAX_GAIN),
                 voice: play_msg.voice,
                 channel_map: play_msg.channel_map,
                 fade_in: play_msg.fade_in,
@@ -440,6 +455,16 @@ pub fn parse_command(json: &str) -> Result<AudioCommand, ParseError> {
         }
         "stopall" | "soundStopAll" => {
             Ok(AudioCommand::StopAll)
+        }
+        "fadeall" | "soundFadeAll" => {
+            let time_ms = if mqtt_cmd.has_params() {
+                let msg: FadeAllMessage = serde_json::from_value(mqtt_cmd.get_params())?;
+                msg.time.unwrap_or(DEFAULT_FADE_ALL_MS)
+            } else {
+                DEFAULT_FADE_ALL_MS
+            };
+
+            Ok(AudioCommand::FadeAll { time_ms })
         }
         "voice_stop" => {
             if !mqtt_cmd.has_params() {
@@ -779,6 +804,87 @@ mod tests {
         match cmd {
             AudioCommand::StopAll => {}, // OK
             _ => panic!("Expected StopAll command"),
+        }
+    }
+
+    #[test]
+    fn test_parse_play_allows_boost() {
+        let json = r#"{"command": "play", "file": "quiet.wav", "volume": 2.5}"#;
+        let cmd = parse_command(json).unwrap();
+
+        match cmd {
+            AudioCommand::Play { volume, .. } => assert_eq!(volume, 2.5),
+            _ => panic!("Expected Play command"),
+        }
+    }
+
+    #[test]
+    fn test_parse_play_clamps_excessive_volume() {
+        let json = r#"{"command": "play", "file": "quiet.wav", "volume": 100.0}"#;
+        let cmd = parse_command(json).unwrap();
+
+        match cmd {
+            AudioCommand::Play { volume, .. } => {
+                assert_eq!(volume, crate::config::MAX_GAIN)
+            }
+            _ => panic!("Expected Play command"),
+        }
+    }
+
+    #[test]
+    fn test_parse_fadeall_command() {
+        let json = r#"{"command": "fadeall", "time": 2000}"#;
+        let cmd = parse_command(json).unwrap();
+
+        match cmd {
+            AudioCommand::FadeAll { time_ms } => assert_eq!(time_ms, 2000),
+            _ => panic!("Expected FadeAll command"),
+        }
+    }
+
+    #[test]
+    fn test_parse_fadeall_nested() {
+        let json = r#"{"command": "fadeall", "message": {"time": 1500}}"#;
+        let cmd = parse_command(json).unwrap();
+
+        match cmd {
+            AudioCommand::FadeAll { time_ms } => assert_eq!(time_ms, 1500),
+            _ => panic!("Expected FadeAll command"),
+        }
+    }
+
+    #[test]
+    fn test_parse_fadeall_without_time() {
+        // "fade everything out" should work as a bare command, the way stopall does
+        let json = r#"{"command": "fadeall"}"#;
+        let cmd = parse_command(json).unwrap();
+
+        match cmd {
+            AudioCommand::FadeAll { time_ms } => assert_eq!(time_ms, DEFAULT_FADE_ALL_MS),
+            _ => panic!("Expected FadeAll command"),
+        }
+    }
+
+    #[test]
+    fn test_parse_sound_fadeall_alias() {
+        let json = r#"{"command": "soundFadeAll"}"#;
+        let cmd = parse_command(json).unwrap();
+
+        match cmd {
+            AudioCommand::FadeAll { time_ms } => assert_eq!(time_ms, DEFAULT_FADE_ALL_MS),
+            _ => panic!("Expected FadeAll command"),
+        }
+    }
+
+    #[test]
+    fn test_parse_fadeall_accepts_fade_out_ms() {
+        // "fade_out_ms" is what stop uses for the same idea
+        let json = r#"{"command": "fadeall", "fade_out_ms": 750}"#;
+        let cmd = parse_command(json).unwrap();
+
+        match cmd {
+            AudioCommand::FadeAll { time_ms } => assert_eq!(time_ms, 750),
+            _ => panic!("Expected FadeAll command"),
         }
     }
 

--- a/src/voice.rs
+++ b/src/voice.rs
@@ -131,7 +131,7 @@ impl VoiceManager {
     /// Set voice volume
     pub fn set_voice_volume(&mut self, voice_id: &str, volume: f32) -> bool {
         if let Some(voice) = self.voices.get_mut(voice_id) {
-            voice.volume = volume.clamp(0.0, 1.0);
+            voice.volume = volume.clamp(0.0, crate::config::MAX_GAIN);
             true
         } else {
             false
@@ -326,9 +326,13 @@ mod tests {
         assert!(manager.set_voice_volume("ambience", 0.5));
         assert_eq!(manager.get_voice_volume("ambience"), Some(0.5));
 
-        // Volume should clamp
+        // Boosting above unity is allowed
         manager.set_voice_volume("ambience", 2.0);
-        assert_eq!(manager.get_voice_volume("ambience"), Some(1.0));
+        assert_eq!(manager.get_voice_volume("ambience"), Some(2.0));
+
+        // Volume should clamp at both ends
+        manager.set_voice_volume("ambience", 100.0);
+        assert_eq!(manager.get_voice_volume("ambience"), Some(crate::config::MAX_GAIN));
 
         manager.set_voice_volume("ambience", -0.5);
         assert_eq!(manager.get_voice_volume("ambience"), Some(0.0));

--- a/tests/http_api_test.rs
+++ b/tests/http_api_test.rs
@@ -20,6 +20,7 @@ fn create_test_state() -> (AppState, mpsc::Receiver<String>) {
         active_samples: Vec::new(),
         live_inputs: Vec::new(),
         output_channels: 2,
+        channel_gains: vec![1.0; 2],
         ducking_engine: None,
         bass_management: None,
     }));
@@ -177,6 +178,75 @@ async fn test_stopall_endpoint() {
     let received = rx.try_recv().unwrap();
     let parsed: serde_json::Value = serde_json::from_str(&received).unwrap();
     assert_eq!(parsed["command"], "stopall");
+}
+
+#[tokio::test]
+async fn test_fadeall_endpoint() {
+    let (state, mut rx) = create_test_state();
+    let app = create_router(state, false, false);
+
+    let request = Request::builder()
+        .method(Method::POST)
+        .uri("/fadeall")
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(r#"{"time": 2500}"#))
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let received = rx.try_recv().unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&received).unwrap();
+    assert_eq!(parsed["command"], "fadeall");
+    assert_eq!(parsed["message"]["time"], 2500);
+}
+
+#[tokio::test]
+async fn test_fadeall_endpoint_without_time() {
+    let (state, mut rx) = create_test_state();
+    let app = create_router(state, false, false);
+
+    let request = Request::builder()
+        .method(Method::POST)
+        .uri("/fadeall")
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from("{}"))
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let received = rx.try_recv().unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&received).unwrap();
+    assert_eq!(parsed["command"], "fadeall");
+}
+
+#[tokio::test]
+async fn test_fadeall_endpoint_emits_a_parseable_command() {
+    // The endpoint and the parser have to agree on the JSON shape, which is
+    // the seam neither side's own tests cover.
+    let (state, mut rx) = create_test_state();
+    let app = create_router(state, false, false);
+
+    let request = Request::builder()
+        .method(Method::POST)
+        .uri("/fadeall")
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(r#"{"time": 3000}"#))
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let received = rx.try_recv().unwrap();
+    match mqttaudio::mqtt::commands::parse_command(&received).unwrap() {
+        mqttaudio::mqtt::commands::AudioCommand::FadeAll { time_ms } => {
+            assert_eq!(time_ms, 3000)
+        }
+        other => panic!("Expected FadeAll, got {:?}", other),
+    }
 }
 
 #[tokio::test]

--- a/tests/http_api_test.rs
+++ b/tests/http_api_test.rs
@@ -3,7 +3,7 @@
 
 use axum::body::Body;
 use axum::http::{header, Method, Request, StatusCode};
-use mqttaudio::audio::mixer::{ActiveSample, MixerState};
+use mqttaudio::audio::mixer::{ActiveSample, LiveInput, MixerState};
 use mqttaudio::audio::types::DecodedBuffer;
 use mqttaudio::cache::CacheManager;
 use mqttaudio::http::{create_router, AppState, LogBroadcaster};
@@ -351,6 +351,53 @@ async fn test_inputs_endpoint() {
     let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
 
     assert!(json["inputs"].is_array());
+}
+
+#[tokio::test]
+async fn test_inputs_endpoint_reports_health() {
+    // Overruns, trims and starvation on a microphone are the first thing to
+    // check when routing sounds wrong, so they belong in the status payload.
+    let (state, _rx) = create_test_state();
+
+    let rb = ringbuf::HeapRb::<f32>::new(400);
+    let (mut producer, consumer) = rb.split();
+    producer.push_slice(&[0.5f32; 20]);
+
+    let mut input = LiveInput::new(
+        "mic".to_string(),
+        consumer,
+        2,
+        0.75,
+        vec![(0, 0), (1, 1)],
+    );
+    input.trimmed_frames = 3;
+    input.underrun_frames = 7;
+    input.dropped_frames.store(11, std::sync::atomic::Ordering::Relaxed);
+
+    state.mixer_state.lock().unwrap().live_inputs.push(input);
+
+    let app = create_router(state, false, false);
+    let request = Request::builder()
+        .method(Method::GET)
+        .uri("/status/inputs")
+        .body(Body::empty())
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+    let input = &json["inputs"][0];
+    assert_eq!(input["voice_id"], "mic");
+    assert_eq!(input["channels"], 2);
+    assert_eq!(input["backlog_frames"], 10);
+    assert_eq!(input["dropped_frames"], 11);
+    assert_eq!(input["trimmed_frames"], 3);
+    assert_eq!(input["underrun_frames"], 7);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Live input (microphone capture) was unusable on multichannel interfaces due to four separate defects in the capture pipeline. This PR fixes all of them, making capture reliable and supporting devices with arbitrary channel counts.

## Key Changes

**Capture ring buffer handling**
- Frames are now read in bulk into a preallocated scratch buffer instead of through a fixed 16-element array, eliminating the channel ceiling and allowing devices with 20+ channels to work correctly
- Ring buffer transfers are now whole-frame only; partial frames that would shift channel interleaving are counted as dropped instead
- Added backlog ceiling to prevent unbounded latency growth when capture clock outruns output clock

**Realtime safety**
- Removed allocations and logging from capture callbacks by using preallocated buffers and atomic counters
- Capture health (overruns, underruns, trimmed frames) is now reported from a background task every 10 seconds and via `/status/inputs` endpoint
- Added `LiveInput::backlog_frames()` and `LiveInput::dropped_frames()` accessors for health monitoring

**Configuration and routing**
- Added `channels` and `sample_rate` fields to `InputConfig` to allow explicit control over capture stream parameters
- Implemented `find_input_config()` to select appropriate capture configuration based on routing needs
- Added `select_channel_count()` to choose the smallest supported channel count that covers all routed source channels
- Improved ALSA device name matching to support both `hw:` and `plughw:` aliases

**Volume and gain handling**
- Changed volume controls from 0.0-1.0 range to 0.0-4.0 (unity at 1.0) to allow boosting quiet microphones or underpowered subwoofers
- Added per-channel output gains via `audio.channel_volumes` configuration
- Added `MAX_GAIN` constant (4.0) enforced across all volume controls

**New features**
- Added `fadeall` command to fade out all active samples over a specified duration
- Added `/status/inputs` HTTP endpoint to report live input health metrics
- Added input health monitoring task that logs capture issues every 10 seconds

## Implementation Details

The scratch buffer in `LiveInput` is preallocated to the ring buffer's capacity during construction, ensuring the audio callback never allocates. Frame alignment is maintained by only consuming whole frames from the ring buffer and tracking partial-frame drops separately.

The backlog ceiling is set to half the ring buffer capacity; frames beyond this are discarded in whole-frame chunks to keep latency bounded while the capture clock runs faster than output.

Capture health metrics (dropped frames, trimmed frames, underrun frames) are stored as atomics in `LiveInput` and reported from a background task to avoid blocking the audio thread.

Configuration resolution now validates that requested channel counts are supported and falls back gracefully when devices misreport capabilities.

https://claude.ai/code/session_01EVcCW7vQbSigpBwSAKhR43